### PR TITLE
fix(compliance): block private history pushes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,63 @@
 #!/usr/bin/env sh
 set -eu
 repo_root="$(git rev-parse --show-toplevel)"
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$repo_root/scripts/verify_open_source_release.ps1" -Mode Light -RepositoryRoot "$repo_root"
+remote_name="${1:-origin}"
+zero_sha="0000000000000000000000000000000000000000"
+base_ref="refs/remotes/$remote_name/main"
+
+if ! git show-ref --verify --quiet "$base_ref"; then
+  base_ref="refs/remotes/origin/main"
+fi
+if ! git show-ref --verify --quiet "$base_ref"; then
+  base_ref="refs/heads/main"
+fi
+if ! git show-ref --verify --quiet "$base_ref"; then
+  echo "Open-source compliance: public main reference is unavailable; fetch origin/main first." >&2
+  exit 1
+fi
+
+base_sha="$(git rev-parse "$base_ref")"
+mode="Light"
+verify_sha=""
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -n "${local_ref:-}" ] || continue
+  [ "$local_sha" != "$zero_sha" ] || continue
+
+  case "$remote_ref" in
+    refs/heads/freerdp-ohos)
+      continue
+      ;;
+    refs/tags/*)
+      mode="Release"
+      ;;
+  esac
+
+  case "$remote_ref" in
+    refs/heads/*|refs/tags/*)
+      commit_sha="$(git rev-parse "${local_sha}^{commit}" 2>/dev/null)" || {
+        echo "Open-source compliance: $remote_ref does not resolve to a commit." >&2
+        exit 1
+      }
+      if ! git merge-base --is-ancestor "$base_sha" "$commit_sha"; then
+        echo "Open-source compliance: refusing to publish history unrelated to public main: $remote_ref" >&2
+        echo "Create the branch from origin/main and cherry-pick only audited changes." >&2
+        exit 1
+      fi
+      if [ -n "$verify_sha" ] && [ "$verify_sha" != "$commit_sha" ]; then
+        echo "Open-source compliance: push one audited commit tip at a time." >&2
+        exit 1
+      fi
+      verify_sha="$commit_sha"
+      ;;
+  esac
+done
+
+[ -n "$verify_sha" ] || exit 0
+
+temp_worktree="$repo_root/.worktrees/pre-push-$$"
+cleanup() {
+  git -C "$repo_root" worktree remove --force "$temp_worktree" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+git -C "$repo_root" worktree add --detach --quiet "$temp_worktree" "$verify_sha"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$temp_worktree/scripts/verify_open_source_release.ps1" -Mode "$mode" -RepositoryRoot "$temp_worktree"

--- a/scripts/tests/test_open_source_compliance.ps1
+++ b/scripts/tests/test_open_source_compliance.ps1
@@ -38,4 +38,9 @@ if ($LASTEXITCODE -ne 0) {
   throw "Compliance gate returned exit code $LASTEXITCODE."
 }
 
+& (Join-Path $PSScriptRoot 'test_pre_push_history_guard.ps1')
+if ($LASTEXITCODE -ne 0) {
+  throw "Pre-push history guard test returned exit code $LASTEXITCODE."
+}
+
 Write-Host 'Open-source compliance gate smoke test passed.'

--- a/scripts/tests/test_pre_push_history_guard.ps1
+++ b/scripts/tests/test_pre_push_history_guard.ps1
@@ -1,0 +1,65 @@
+$ErrorActionPreference = 'Stop'
+
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$hook = Join-Path $repo '.githooks\pre-push'
+$bash = 'C:\Program Files\Git\bin\bash.exe'
+$zero = '0' * 40
+
+$tree = (& git -C $repo rev-parse 'HEAD^{tree}').Trim()
+$publicHead = (& git -C $repo rev-parse HEAD).Trim()
+$oldAuthorName = $env:GIT_AUTHOR_NAME
+$oldAuthorEmail = $env:GIT_AUTHOR_EMAIL
+$oldCommitterName = $env:GIT_COMMITTER_NAME
+$oldCommitterEmail = $env:GIT_COMMITTER_EMAIL
+try {
+  $env:GIT_AUTHOR_NAME = 'Compliance Test'
+  $env:GIT_AUTHOR_EMAIL = 'compliance-test@example.invalid'
+  $env:GIT_COMMITTER_NAME = $env:GIT_AUTHOR_NAME
+  $env:GIT_COMMITTER_EMAIL = $env:GIT_AUTHOR_EMAIL
+  $unrelated = (& git -C $repo commit-tree $tree -m 'test: unrelated public history').Trim()
+} finally {
+  $env:GIT_AUTHOR_NAME = $oldAuthorName
+  $env:GIT_AUTHOR_EMAIL = $oldAuthorEmail
+  $env:GIT_COMMITTER_NAME = $oldCommitterName
+  $env:GIT_COMMITTER_EMAIL = $oldCommitterEmail
+}
+
+$publicLine = "refs/heads/codex/public-test $publicHead refs/heads/codex/public-test $zero"
+$publicLine | & $bash $hook origin 'https://github.com/Mydstiny/RemoteDeskHarmonyOS.git'
+if ($LASTEXITCODE -ne 0) {
+  throw 'Pre-push history guard rejected a branch based on public main.'
+}
+
+$tagLine = "refs/tags/v-test $publicHead refs/tags/v-test $zero"
+$previousErrorAction = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+  $tagOutput = @($tagLine | & $bash $hook origin 'https://github.com/Mydstiny/RemoteDeskHarmonyOS.git' 2>&1)
+  $tagExit = $LASTEXITCODE
+} finally {
+  $ErrorActionPreference = $previousErrorAction
+}
+if ($tagExit -eq 0) {
+  throw 'Pre-push history guard allowed a release tag without the Release gate.'
+}
+if (($tagOutput -join "`n") -notmatch 'Release blocked') {
+  throw 'Pre-push history guard rejected the tag for an unexpected reason.'
+}
+
+$unrelatedLine = "refs/heads/codex/private-history $unrelated refs/heads/codex/private-history $zero"
+$ErrorActionPreference = 'Continue'
+try {
+  $unrelatedOutput = @($unrelatedLine | & $bash $hook origin 'https://github.com/Mydstiny/RemoteDeskHarmonyOS.git' 2>&1)
+  $unrelatedExit = $LASTEXITCODE
+} finally {
+  $ErrorActionPreference = $previousErrorAction
+}
+if ($unrelatedExit -eq 0) {
+  throw 'Pre-push history guard allowed an unrelated private-history branch.'
+}
+if (($unrelatedOutput -join "`n") -notmatch 'unrelated to public main') {
+  throw 'Pre-push history guard rejected unrelated history for an unexpected reason.'
+}
+
+Write-Host 'Pre-push public-history guard test passed.'
+exit 0


### PR DESCRIPTION
## What changed
- reject branches and tags whose commits are unrelated to the sanitized public main
- run compliance against the exact pushed commit in a temporary clean worktree
- require the Release gate before any tag can be published
- add regression coverage for allowed public history, blocked private history, and blocked unapproved tags

## Why
The public main was sanitized, but local legacy branches still contain pre-migration history. A tree-only pre-push check could otherwise make that history reachable again through a new remote branch.

## Validation
- open-source compliance suite passed
- About disclosure test passed
- Opus artifact location test passed
- FreeRDP provenance test passed
- real feature-branch push passed the new pre-push Light gate