### PR TITLE
fix(compliance): support shallow history checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -34,10 +34,14 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 
   case "$remote_ref" in
     refs/heads/*|refs/tags/*)
-      commit_sha="$(git rev-parse "${local_sha}^{commit}" 2>/dev/null)" || {
+      commit_sha="$(git rev-list -n 1 "$local_sha" 2>/dev/null)" || {
         echo "Open-source compliance: $remote_ref does not resolve to a commit." >&2
         exit 1
       }
+      if [ -z "$commit_sha" ] || [ "$(git cat-file -t "$commit_sha" 2>/dev/null)" != "commit" ]; then
+        echo "Open-source compliance: $remote_ref does not resolve to a commit." >&2
+        exit 1
+      fi
       if ! git merge-base --is-ancestor "$base_sha" "$commit_sha"; then
         echo "Open-source compliance: refusing to publish history unrelated to public main: $remote_ref" >&2
         echo "Create the branch from origin/main and cherry-pick only audited changes." >&2

--- a/scripts/tests/test_pre_push_history_guard.ps1
+++ b/scripts/tests/test_pre_push_history_guard.ps1
@@ -5,6 +5,8 @@ $hook = Join-Path $repo '.githooks\pre-push'
 $bash = 'C:\Program Files\Git\bin\bash.exe'
 $zero = '0' * 40
 
+Push-Location $repo
+
 $tree = (& git -C $repo rev-parse 'HEAD^{tree}').Trim()
 $publicHead = (& git -C $repo rev-parse HEAD).Trim()
 $oldAuthorName = $env:GIT_AUTHOR_NAME
@@ -61,5 +63,6 @@ if (($unrelatedOutput -join "`n") -notmatch 'unrelated to public main') {
   throw 'Pre-push history guard rejected unrelated history for an unexpected reason.'
 }
 
+Pop-Location
 Write-Host 'Pre-push public-history guard test passed.'
 exit 0


### PR DESCRIPTION
## What changed
- peel pushed commits with `git rev-list` plus `git cat-file` instead of `^{commit}`
- run the hook regression from the repository under test

## Why
A depth-limited Windows Git Bash clone could see an unreachable test commit but fail the `^{commit}` peeling expression. The test also needed to set its current directory to the target clone so the hook inspects the correct object database.

## Validation
- local compliance/history suite passed
- depth-3 shallow clone with an explicit `origin/main` baseline passed
- actual pre-push Light gate passed for this branch