### PR TITLE
Standardize workflow and publish 1.0.6 metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,31 @@ Phase 5+ 完成 → Phase 6 (主机安全锁 40%) + Phase 7 (测试/发布)
 
 > **编代码前先查 `CODEWALK.md`** — 里面有所有编码规则、架构约束和已知坑位。
 
+## 唯一工作区与开源 Push 铁律
+
+- 唯一允许进行开发、构建、提交和发布操作的工作区是
+  `C:\Users\14288\DevEcoStudioProjects\RemoteDesktop`。
+- 每个新任务必须先切到公开 `main`，执行 `git pull --ff-only`，再在同一
+  工作区创建 `codex/...` 功能分支。除非用户明确重新授权，不得使用旧
+  worktree，也不得从旧私有历史分支继续开发。
+- 只暂存本任务文件。禁止 `git add -A` 混入用户文件，禁止
+  `git push --all`、直接推送 `main`、force-push、推送与公开 `main`
+  无祖先关系的历史，以及恢复已删除的旧 tag。
+- 推送前必须确认 `core.hooksPath=.githooks`。`.githooks/pre-push` 会对实际
+  推送 commit 运行开源合规门：普通分支为 Light，tag 为 Release。
+- 标准流程固定为：公开 `main` → `git pull --ff-only` → `codex/...` →
+  修改与验证 → push 功能分支 → PR → required `open-source-compliance`
+  通过 → 合入受保护 `main` → 切回 `main` → `git pull --ff-only`。
+- 依赖、proto、许可证或构建输入变化必须在同一 PR 更新 SBOM、NOTICE、
+  provenance 和哈希。Release gate 未通过前禁止发布 tag 或正式二进制
+  Release；未签名测试 HAP 只能按用户明确批准的 Draft/Pre-release 流程
+  上传，且绝不能上传本地签名 HAP。
+
 ## 本地参考
 - API 23 文档：`C:\Users\14288\harmonyos_support\openharmony-docs-api23\zh-cn\application-dev\reference\`
 - Codex 记忆：`C:\Users\14288\.codex\projects\C--Users-14288\memory\`
 - 构建命令：见 `CODEWALK.md` §8
+- Git/Push 规则记忆：`open-source-git-workflow.md`
 
 ---
 

--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.example.remotedesktop",
     "vendor": "example",
-    "versionCode": 1000005,
-    "versionName": "1.0.5",
+    "versionCode": 1000006,
+    "versionName": "1.0.6",
     "icon": "$media:layered_image",
     "label": "$string:app_name",
     "cloudStructuredDataSyncEnabled": true

--- a/README.md
+++ b/README.md
@@ -1,45 +1,203 @@
 # RemoteDeskHarmonyOS
 
-HarmonyOS NEXT 原生远程桌面客户端，支持 RDP、RustDesk、SSH/SFTP 与
-VNC，并包含云同步、主机安全锁、后台实况与多端响应式界面。
+面向 HarmonyOS NEXT PC 的原生多协议远程桌面客户端。当前版本为
+**1.0.6**（`versionCode 1000006`），在一个 ArkUI 工作台中提供 RDP、
+RustDesk、SSH/SFTP 和 VNC 连接，并集成华为云数据同步、本地加密、后台
+实况和多窗口响应式体验。
 
-## License and source
+> 当前仓库仍处于测试与发布验证阶段。GitHub 中标记为 `unsigned` 的 HAP
+> 未经应用签名，仅用于开发测试；它不是 AppGallery 或生产分发安装包。
 
-项目自有组合发行版采用 **AGPL-3.0-or-later**。FreeRDP、OpenSSL、
-FFmpeg、libssh2、Mbed TLS、Opus、Rust crates 与 Huawei/OpenHarmony
-包保留各自许可证。请阅读 `LICENSE`、`NOTICE`、
-`THIRD_PARTY_NOTICES.md` 和 `docs/compliance/SBOM.spdx.json`。
+## 功能概览
 
-每个公开二进制 release 必须对应同名 source tag、发布清单、SBOM 和
-完整对应源码。网络交互版本的源码提供策略见
-`docs/compliance/AGPL_NETWORK_SOURCE_OFFER_POLICY.md`。
+| 能力 | 当前实现 |
+|---|---|
+| RDP | 基于 FreeRDP/WinPR，支持证书预检、Microsoft/Azure AD 凭据、音视频、输入、纯文本剪贴板和共享目录 |
+| RustDesk | 原生 Rust FFI 客户端链路，支持 rendezvous/relay/direct、视频、音频、输入、纯文本剪贴板和文件传输 |
+| SSH/SFTP | 终端、密钥与密码认证、主屏 scrollback、文件浏览、上传/下载、取消和安全续传 |
+| VNC | 原生 VNC 连接、显示和输入路径 |
+| 主机工作台 | 收藏、最近使用、工作组、排序、连接入口与协议过滤 |
+| 数据与安全 | RDB、本地 AES-256-GCM 数据保护、HUKS/生物认证集成、备份恢复与主机安全锁建设 |
+| 华为云同步 | 七张固定业务表的显式同步、选择控制、重试、下载回滚与本地恢复隔离 |
+| HarmonyOS 体验 | PC/Pad/Phone 响应式布局、沉浸式浮动导航、后台会话实况与前后台恢复 |
 
-## Secure local configuration
+部分能力依赖远端服务器配置、HarmonyOS 设备形态、系统权限和本地私有
+AGConnect 配置。正式 Release 还需要通过完整四协议设备矩阵与凭据轮换
+确认；仓库不会把未完成的外部验证描述为已经通过。
 
-仓库不包含 AGConnect secret、API key、签名口令、证书或本机 SDK 路径。
-从 `build-profile.example.json5`、`local.properties.example` 和
-`agconnect-services.example.json` 创建本地私有配置；真实值只可来自
-本机安全路径或 CI secrets。
+## 支持平台与技术栈
 
-## Build
+- HarmonyOS NEXT，项目以 API 23 SDK 为当前开发基线。
+- ArkTS + ArkUI 声明式 UI，使用 HarmonyOS 原生 Kit。
+- C/C++ NAPI 扩展承载 FreeRDP、VNC、音视频、渲染和输入桥接。
+- Rust 承载 RustDesk 协议桥和 SSH 终端相关逻辑。
+- 构建系统为 DevEco Studio Hvigor；当前产物覆盖 ARM64 与 x86_64 原生库。
 
-1. 安装 DevEco Studio 与 API 23 SDK。
-2. 准备私有根 `build-profile.json5` 和真实（但不跟踪的）
-   `entry/src/main/resources/rawfile/agconnect-services.json`。
-3. 首次 clean clone 或修改 RustDesk FFI 后，运行
-   `scripts/build_rustdesk_ffi_ohos.sh all`。
-4. 使用 DevEco 的 Node/Hvigor 执行：
+## 架构
 
 ```text
-hvigorw.js --mode module -p module=entry -p product=default assembleHap --analyze=normal --parallel --incremental --daemon
+ArkUI pages/components
+        │
+        ├── services / policies / RDB / cloud coordination
+        │
+        └── rdpnapi (NAPI boundary)
+              ├── FreeRDP / WinPR ── RDP
+              ├── rustdesk_ffi ───── RustDesk
+              ├── libssh2 / terminal core ── SSH/SFTP
+              ├── VNC adapter
+              └── decoder / renderer / audio / input bridges
 ```
 
-在提交或自动推送前运行：
+协议会话、渲染、音频、输入、剪贴板和文件传输保持明确边界。可选能力失败
+不应破坏已经建立的桌面会话；云同步和加密写入必须先确认本地事务成功，
+再更新缓存或请求推送。
+
+## 仓库结构
+
+| 路径 | 用途 |
+|---|---|
+| `AppScope/` | 应用级清单、版本与资源 |
+| `entry/src/main/ets/` | ArkTS 页面、组件、模型、服务和策略 |
+| `entry/src/main/cpp/` | NAPI、协议适配、渲染、音视频与原生测试 |
+| `rustdesk_ffi/` | RustDesk Rust FFI、协议会话与 Rust 测试 |
+| `freerdp/` | 指向本仓库公开 `freerdp-ohos` 分支的 FreeRDP 子模块 |
+| `scripts/` | 依赖构建、SBOM、合规、clean-clone 和 Git hook 脚本 |
+| `docs/compliance/` | SPDX SBOM、来源、发布门禁、回滚和开源合规记录 |
+| `LICENSES/` | 项目与第三方许可证文本 |
+
+## 获取源码
 
 ```powershell
-pwsh -File scripts/verify_open_source_release.ps1 -Mode Light
+git clone --recurse-submodules https://github.com/Mydstiny/RemoteDeskHarmonyOS.git
+Set-Location RemoteDeskHarmonyOS
 ```
 
-本地钩子安装：`pwsh -File scripts/install_git_hooks.ps1`。GitHub Actions
-会再次运行相同门禁；release 还必须通过 clean-clone、双 ABI、HAP、
-ABI 与设备矩阵检查。
+如果已普通 clone，执行 `git submodule update --init --recursive`。FreeRDP
+OHOS 修改历史位于同一 GitHub 仓库的 `freerdp-ohos` 分支；主分支通过
+gitlink 固定到可复现修订。
+
+## 本地私有配置
+
+仓库不会跟踪签名证书、口令、AGConnect secret、API key、本机 SDK 路径
+或真实用户数据。首次构建时按示例创建本地文件：
+
+- `build-profile.example.json5` → 本地 `build-profile.json5`
+- `local.properties.example` → 本地 `local.properties`
+- `entry/src/main/resources/rawfile/agconnect-services.example.json` → 本地
+  `agconnect-services.json`
+
+真实值只能保存在本机安全路径或 CI secrets。不要把这些文件加入 Git，
+也不要在 issue、日志或截图中公开它们。
+
+## 构建依赖
+
+1. 安装 DevEco Studio 和 HarmonyOS API 23 SDK。
+2. 安装 Git、PowerShell 7、Rust/Cargo，以及项目脚本所需的 C/C++ 工具链。
+3. 准备上述本地私有配置。
+4. 首次 clean clone 或 RustDesk/Opus 输入变化后构建双 ABI 原生依赖：
+
+```text
+bash scripts/build_opus_ohos.sh all
+bash scripts/build_rustdesk_ffi_ohos.sh all
+```
+
+FreeRDP、FFmpeg 或其他原生依赖变化时，使用 `scripts/` 下对应的 OHOS 构建
+脚本，并同步更新来源、许可证、SBOM 和产物哈希。
+
+## 构建 HAP
+
+在 Windows PowerShell 中：
+
+```powershell
+$env:DEVECO_SDK_HOME = 'C:\Program Files\Huawei\DevEco Studio\sdk'
+$env:OHOS_SDK_HOME = $env:DEVECO_SDK_HOME
+& 'C:\Program Files\Huawei\DevEco Studio\tools\node\node.exe' `
+  'C:\Program Files\Huawei\DevEco Studio\tools\hvigor\bin\hvigorw.js' `
+  --mode module -p module=entry -p product=default assembleHap `
+  --analyze=normal --parallel --incremental --daemon
+```
+
+常见输出目录：
+
+```text
+entry/build/default/outputs/default/entry-default-unsigned.hap
+entry/build/default/outputs/default/entry-default-signed.hap
+```
+
+签名产物仅属于本地私有发布流程，不得上传到本仓库的 unsigned 测试
+Release。
+
+## 测试与验证
+
+```powershell
+# 开源合规轻量门禁
+pwsh -File scripts/verify_open_source_release.ps1 -Mode Light
+
+# 安装并确认本地 pre-push hook
+pwsh -File scripts/install_git_hooks.ps1
+git config --get core.hooksPath
+```
+
+其他主要验证入口：
+
+- ArkTS：`default@OhosTestCompileArkTS` 与 `onDeviceTest` 任务图。
+- Native：项目生成的 `rdp_native_tests` 测试程序。
+- Rust：在 `rustdesk_ffi/` 执行 `cargo test --lib --no-default-features`。
+- Clean clone：`scripts/verify_clean_clone_build.ps1`。
+- 正式发布：`scripts/verify_open_source_release.ps1 -Mode Release`。
+
+Release 模式还要求凭据轮换、完整设备矩阵和私有构建配置，不能用一次
+Light 通过或一次本地 HAP 构建代替。
+
+## 开发与 Push 流程
+
+项目唯一标准工作区为：
+
+```text
+C:\Users\14288\DevEcoStudioProjects\RemoteDesktop
+```
+
+维护者和自动化 session 必须从公开、干净的 `main` 开始，并在同一工作区
+创建 `codex/...` 功能分支：
+
+```powershell
+git switch main
+git pull --ff-only
+git switch -c codex/<task-name>
+# 修改、测试、构建、运行 Light gate
+git push -u origin codex/<task-name>
+```
+
+之后创建 PR，等待 required `open-source-compliance` 通过，再合入受保护的
+`main`。合并后执行 `git switch main` 和 `git pull --ff-only`。
+
+禁止从旧 worktree 或旧私有历史继续开发，禁止 `git push --all`、直接
+推送 `main`、force-push 或恢复旧 tag。依赖、proto、许可证和构建输入
+变化必须在同一 PR 更新 SBOM、NOTICE、provenance 与哈希。
+
+## 开源许可证与对应源码
+
+项目自有组合发行版采用 **AGPL-3.0-or-later**。FreeRDP、OpenSSL、
+FFmpeg、libssh2、Mbed TLS、Opus、Rust crates 与 Huawei/OpenHarmony 包
+保留各自许可证和分发条件。
+
+请阅读：
+
+- `LICENSE` 与 `LICENSES/`
+- `NOTICE` 与 `THIRD_PARTY_NOTICES.md`
+- `docs/compliance/SBOM.spdx.json`
+- `docs/compliance/SOURCE_OFFER.md`
+- `docs/compliance/AGPL_NETWORK_SOURCE_OFFER_POLICY.md`
+
+公开二进制版本必须能够对应到完整源码、构建脚本、SBOM、第三方来源和
+明确的源码修订。未发布的 unsigned draft 不代表正式 Release 验收完成。
+
+## 参与贡献与安全报告
+
+贡献要求见 `CONTRIBUTING.md`。提交默认采用 AGPL-3.0-or-later，并使用
+Developer Certificate of Origin sign-off；PR 必须说明协议、ABI、schema、
+权限和用户行为变化及相应验证证据。
+
+安全问题请优先通过 GitHub Security Advisory 私密报告；备用联系方式与
+敏感信息处理规则见 `SECURITY.md`。请勿在公开 issue 中提交凭据、主机
+地址、证书、数据库备份或原始远程日志。

--- a/docs/compliance/RELEASE_MANIFEST.example.json
+++ b/docs/compliance/RELEASE_MANIFEST.example.json
@@ -1,5 +1,5 @@
 {
-  "releaseTag": "v1.0.5-agpl.1",
+  "releaseTag": "v1.0.6-unsigned.1",
   "sourceCommit": "0000000000000000000000000000000000000000",
   "hapSha256": "0000000000000000000000000000000000000000000000000000000000000000",
   "sbomSha256": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -8,6 +8,6 @@
   "freerdpSubmoduleCommit": "dae8276ac7361b8d14f7b87d41163fe03dbb944e",
   "buildCommand": "hvigorw.js --mode module -p module=entry -p product=default assembleHap",
   "toolchainVersions": {},
-  "sourceOfferUrl": "https://github.com/Mydstiny/RemoteDeskHarmonyOS/tree/v1.0.5-agpl.1",
+  "sourceOfferUrl": "https://github.com/Mydstiny/RemoteDeskHarmonyOS",
   "generatedAtUtc": "2026-07-13T00:00:00Z"
 }

--- a/docs/compliance/SBOM.spdx.json
+++ b/docs/compliance/SBOM.spdx.json
@@ -2,10 +2,10 @@
     "spdxVersion":  "SPDX-2.3",
     "dataLicense":  "CC0-1.0",
     "SPDXID":  "SPDXRef-DOCUMENT",
-    "name":  "RemoteDeskHarmonyOS-4c5a573a13000844fc558667449ca4d7770e9d6b",
-    "documentNamespace":  "https://github.com/Mydstiny/RemoteDeskHarmonyOS/spdx/4c5a573a13000844fc558667449ca4d7770e9d6b",
+    "name":  "RemoteDeskHarmonyOS-90326ed47a2602abd120fbd71e456fb88b4c4c20",
+    "documentNamespace":  "https://github.com/Mydstiny/RemoteDeskHarmonyOS/spdx/90326ed47a2602abd120fbd71e456fb88b4c4c20",
     "creationInfo":  {
-                         "created":  "2026-07-13T12:04:23Z",
+                         "created":  "2026-07-13T15:20:51Z",
                          "creators":  [
                                           "Tool: scripts/generate_sbom.ps1",
                                           "Organization: RemoteDeskHarmonyOS"
@@ -15,7 +15,7 @@
                      {
                          "name":  "RemoteDeskHarmonyOS",
                          "SPDXID":  "SPDXRef-Package-RemoteDeskHarmonyOS",
-                         "versionInfo":  "1.0.5",
+                         "versionInfo":  "1.0.6",
                          "downloadLocation":  "https://github.com/Mydstiny/RemoteDeskHarmonyOS",
                          "filesAnalyzed":  false,
                          "licenseConcluded":  "AGPL-3.0-or-later",
@@ -615,8 +615,8 @@
                      {
                          "name":  "RustDesk-protocol",
                          "SPDXID":  "SPDXRef-Native-RustDesk-protocol",
-                         "versionInfo":  "rustdesk:93d064a9b0eb58ab94db88ff727a877ef773c0d8 hbb_common:387603f47cbb15c0d3dc3d67ae3396d3eb707daf",
-                         "downloadLocation":  "https://github.com/rustdesk/hbb_common",
+                         "versionInfo":  "93d064a9b0eb58ab94db88ff727a877ef773c0d8",
+                         "downloadLocation":  "https://github.com/rustdesk/rustdesk",
                          "filesAnalyzed":  false,
                          "licenseConcluded":  "AGPL-3.0",
                          "licenseDeclared":  "AGPL-3.0",

--- a/docs/superpowers/plans/2026-07-13-main-workspace-v1-0-6-publication.md
+++ b/docs/superpowers/plans/2026-07-13-main-workspace-v1-0-6-publication.md
@@ -1,0 +1,96 @@
+# Main Workspace and Version 1.0.6 Publication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize all future sessions on the main workspace and protected push workflow, align the project to 1.0.6, publish a complete README, and upload only an unsigned HAP to a GitHub draft pre-release.
+
+**Architecture:** Repository instructions, shared exchange files, and Codex memory carry the same canonical workflow. Local pre-push and GitHub branch protection enforce it. Version metadata and documentation are changed in one PR; the artifact is built from merged public `main` and stored only in an unpublished draft pre-release.
+
+**Tech Stack:** Git, GitHub CLI, PowerShell, HarmonyOS Hvigor, Markdown, SPDX 2.3.
+
+## Global Constraints
+
+- The only development workspace is `C:\Users\14288\DevEcoStudioProjects\RemoteDesktop`.
+- Start each task from public `main`, then create a `codex/...` feature branch in the same workspace.
+- Never use old worktrees/private history, `git push --all`, direct main pushes, or force-push.
+- Current application version is `1.0.6` / `1000006`.
+- Upload only `entry-default-unsigned.hap`; never upload `entry-default-signed.hap`.
+- GitHub publication target is an unpublished draft pre-release `v1.0.6-unsigned.1` until Release mode passes.
+- Preserve the three pre-existing untracked plan files and do not stage them.
+
+---
+
+### Task 1: Persist the canonical workspace and push workflow
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\CODEWALK.md`
+- Modify: `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\HANDOFF.md`
+- Modify: `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\TASKS.md`
+- Create: `C:\Users\14288\.codex\projects\C--Users-14288\memory\open-source-git-workflow.md`
+- Modify: `C:\Users\14288\.codex\projects\C--Users-14288\memory\MEMORY.md`
+- Modify: `C:\Users\14288\.codex\projects\C--Users-14288\memory\remote-desktop-project-state.md`
+
+- [ ] Add the absolute canonical workspace and exact branch/PR/push sequence to `AGENTS.md`.
+- [ ] Add the same invariant to CODEWALK and current HANDOFF/TASKS entries.
+- [ ] Create focused reusable memory and link it from MEMORY.md; update project state.
+- [ ] Search all updated sources for the canonical path, `git push --all`, and `open-source-compliance`.
+
+### Task 2: Align current version metadata
+
+**Files:**
+- Modify: `AppScope/app.json5`
+- Modify: `entry/src/main/ets/pages/HostListPage.ets`
+- Modify: `scripts/generate_sbom.ps1`
+- Modify: `docs/compliance/SBOM.spdx.json`
+- Modify: `docs/compliance/RELEASE_MANIFEST.example.json`
+
+- [ ] Change the manifest to `versionName: "1.0.6"` and `versionCode: 1000006`.
+- [ ] Change current user-facing backup, feedback, and About version strings to `1.0.6`.
+- [ ] Change the project package version emitted by `generate_sbom.ps1` to `1.0.6` and regenerate the SPDX document.
+- [ ] Update the release-manifest example to the unsigned draft naming without asserting missing approvals.
+- [ ] Verify current-version files contain no stale application `1.0.5` strings while preserving historical fixtures and baselines.
+
+### Task 3: Replace the GitHub README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] Document the four protocols, product capabilities, supported platform, and honest maturity limits.
+- [ ] Document architecture and repository layout.
+- [ ] Document private local configuration, dependency/bootstrap, build, tests, and Light/Release compliance commands.
+- [ ] Document the canonical workspace and protected feature-branch/PR workflow.
+- [ ] Document license, source offer, security, contribution, and unsigned HAP limitations.
+- [ ] Check every referenced repository path exists.
+
+### Task 4: Verify and publish the source PR
+
+**Files:**
+- Verify all files changed by Tasks 1-3.
+
+- [ ] Run `git diff --check` and inspect `git status --short`.
+- [ ] Run `pwsh -File scripts/verify_open_source_release.ps1 -Mode Light` and require exit code 0.
+- [ ] Run the production `assembleHap` command from CODEWALK and require `BUILD SUCCESSFUL`.
+- [ ] Confirm the unsigned HAP exists and compute SHA-256; confirm the signed HAP is not staged.
+- [ ] Stage only intended repository files, commit, and push the `codex/...` branch.
+- [ ] Open a ready pull request, wait for strict `open-source-compliance`, merge it, then return the main workspace to `main` with `git pull --ff-only`.
+
+### Task 5: Create the unsigned draft pre-release
+
+**Files:**
+- Upload: `entry/build/default/outputs/default/entry-default-unsigned.hap`
+
+- [ ] Verify the merged `main` commit and rebuild the HAP if the artifact does not correspond to it.
+- [ ] Calculate and record the unsigned HAP SHA-256 and byte size.
+- [ ] Create an unpublished draft pre-release `v1.0.6-unsigned.1` targeting merged `main` with explicit unsigned/test-only warnings.
+- [ ] Upload only `entry-default-unsigned.hap` and verify the draft asset list contains no signed HAP.
+- [ ] Keep formal `v1.0.6` and all public tags blocked until Release mode succeeds.
+
+### Task 6: Final handoff
+
+**Files:**
+- Modify: Mission_transformation `HANDOFF.md` and `TASKS.md`
+- Modify: Codex `remote-desktop-project-state.md`
+
+- [ ] Record final main commit, PR, Actions result, build result, artifact checksum, and draft release URL.
+- [ ] Confirm the workspace is back on clean public `main` except the three preserved untracked user plan files.

--- a/docs/superpowers/specs/2026-07-13-main-workspace-v1-0-6-publication-design.md
+++ b/docs/superpowers/specs/2026-07-13-main-workspace-v1-0-6-publication-design.md
@@ -1,0 +1,29 @@
+# Main Workspace, Version 1.0.6, and Unsigned Publication Design
+
+## Goal
+
+Make `C:\Users\14288\DevEcoStudioProjects\RemoteDesktop` the only authorized development workspace, make every future Codex session follow the protected open-source push workflow, align the public project to application version `1.0.6` / `1000006`, replace the minimal GitHub README with a complete project guide, and upload only the unsigned HAP as a private GitHub draft pre-release asset.
+
+## Git and session architecture
+
+Every task starts from the clean public `main` in the main workspace and creates a `codex/...` feature branch there. Sessions must never resume development from old worktrees or branches containing the private pre-publication history. Local `.githooks/pre-push` checks the exact pushed commit, and protected GitHub `main` requires the strict `open-source-compliance` check through a pull request.
+
+The rule is stored in three layers: repository-local `AGENTS.md`, the shared Mission_transformation exchange files, and Codex project memory. Local and remote gates remain the enforcement layer if a session overlooks written guidance.
+
+## Version alignment
+
+The application manifest, user-visible version strings, SBOM generator, and generated SBOM identify the project as `1.0.6` / `1000006`. Historical test fixtures, old specifications, and the audited `1.0.5` baseline directory remain unchanged because they describe prior evidence rather than the current application version.
+
+## README structure
+
+The README describes supported protocols and verified product capabilities, HarmonyOS/API requirements, architecture, repository layout, local configuration, complete build commands, tests, open-source compliance, the required contribution/push workflow, security reporting, and unsigned-build installation limitations. It must not claim that pending device/release gates have passed.
+
+## Unsigned artifact publication
+
+Build from the merged public `main`, calculate the unsigned HAP SHA-256, and upload only `entry-default-unsigned.hap` to a GitHub draft pre-release named `v1.0.6-unsigned.1`. The release notes state that the asset is unsigned, test-only, not AppGallery-installable as a production release, and corresponds to an exact public source commit. The signed HAP must never be uploaded.
+
+The draft remains unpublished and creates no public release tag while `credentialsRotated`, `deviceMatrixVerified`, or the private release build profile gate is missing. Formal `v1.0.6` publication remains blocked until Release mode passes.
+
+## Verification
+
+Run version consistency searches, `git diff --check`, the Light compliance gate, version/SBOM assertions, and a fresh production `assembleHap`. Verify the artifact name and checksum, inspect the staged diff, push only the feature branch, merge only after required GitHub checks pass, then rebuild or verify the unsigned HAP from merged `main` before uploading it to the draft release.

--- a/entry/src/main/ets/pages/HostListPage.ets
+++ b/entry/src/main/ets/pages/HostListPage.ets
@@ -805,7 +805,7 @@ struct HostListPage {
 
   private async createLocalBackup(): Promise<void> {
     try {
-      const saved: boolean = await LocalBackupService.getInstance().saveBackup('1.0.5');
+      const saved: boolean = await LocalBackupService.getInstance().saveBackup('1.0.6');
       if (saved) { promptAction.showToast({ message: '本地备份已保存', duration: 1600 }); this.closeSettingsLeafSheet(); }
     } catch (_e) { this.cloudSyncError = '备份失败，请检查保存位置后重试'; }
   }
@@ -926,7 +926,7 @@ struct HostListPage {
 
   private async openFeedbackEmail(): Promise<void> {
     const ctx: common.UIAbilityContext = getContext(this) as common.UIAbilityContext;
-    const versionName: string = '1.0.5';
+    const versionName: string = '1.0.6';
     const attempts: SettingsFeedbackLaunchAttempt[] =
       settingsFeedbackLaunchAttempts(versionName, this.breakpoint, this.isDesktopDevice);
     const params: Record<string, Object> =
@@ -4334,7 +4334,7 @@ struct HostListPage {
             Text('关于').fontSize(13).fontWeight(FontWeight.Medium).fontColor(this.pal().text3)
               .fontFamily(this.font()).padding({ left: 8, bottom: 8 })
             Column() {
-              this.cardItemRow($r('app.media.icon_info'), '版本', '1.0.5 · FreeRDP+RustDesk+SSH')
+              this.cardItemRow($r('app.media.icon_info'), '版本', '1.0.6 · FreeRDP+RustDesk+SSH')
               this.cardDivider()
               this.cardActionRow($r('app.media.icon_info'), '关于应用', '开源协议、作者说明和联系方式',
                 (): void => {

--- a/scripts/generate_sbom.ps1
+++ b/scripts/generate_sbom.ps1
@@ -11,7 +11,7 @@ $packages = [System.Collections.Generic.List[object]]::new()
 $packages.Add([ordered]@{
   name = 'RemoteDeskHarmonyOS'
   SPDXID = 'SPDXRef-Package-RemoteDeskHarmonyOS'
-  versionInfo = '1.0.5'
+  versionInfo = '1.0.6'
   downloadLocation = 'https://github.com/Mydstiny/RemoteDeskHarmonyOS'
   filesAnalyzed = $false
   licenseConcluded = 'AGPL-3.0-or-later'


### PR DESCRIPTION
## What changed

- makes the main RemoteDesktop checkout the only authorized workspace and documents the protected branch/PR workflow
- aligns app metadata, user-visible version strings, SBOM generation, and release metadata to 1.0.6 / 1000006
- replaces the minimal README with architecture, capabilities, build, test, compliance, contribution, and security guidance
- records the approved unsigned-only draft pre-release process without weakening the formal Release gate

## Why

Future sessions need one durable workflow that cannot reconnect the private pre-publication history or bypass open-source compliance. GitHub and the application also need one truthful current version and enough documentation for users and contributors to build and evaluate the project.

## Validation

- `scripts/verify_open_source_release.ps1 -Mode Light`
- version/SBOM consistency assertion for 1.0.6 / 1000006
- public-main ancestry and `.githooks` verification
- DevEco `assembleHap`: BUILD SUCCESSFUL in 19 s 65 ms
- `git diff --cached --check`

The signed HAP is not part of this PR and will not be uploaded. After merge, only the unsigned HAP will be attached to an unpublished draft pre-release.