### PR TITLE
fix: enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/feedback-pages.yml
+++ b/.github/workflows/feedback-pages.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pages: write
 
 concurrency:
   group: github-pages
@@ -33,6 +34,8 @@ jobs:
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## 修正

开启 `actions/configure-pages@v5` 的 `enablement`，并授予构建任务 Pages 配置权限，使合并到 main 后能够自动创建并部署 GitHub Pages 站点。

## 验证

- 仅修改 .github/workflows/feedback-pages.yml
- 目标提交基于已合并的反馈二维码 Pages 配置