### PR TITLE
fix(rdp): make session teardown deterministic

### DIFF
--- a/docs/DEVICE_VERIFICATION_CHECKLIST.md
+++ b/docs/DEVICE_VERIFICATION_CHECKLIST.md
@@ -47,6 +47,23 @@ hdc hilog | grep -E "RDP_NAPI|GL_RENDERER|HW_DECODER|RDP_ADAPTER|RUSTDESK|AUDIO|
 | 3.2 | TCP 握手到 MCS | hilog: "RDP skeleton session" (或连接失败) | ⬜ |
 | 3.3 | FreeRDP submodule 存在 | `git submodule status` 显示 freerdp/ commit | ⬜ |
 
+### R3.1: RDP 长连接退出稳定性
+
+采集 `RDP-SHUTDOWN` 与 `ExtLoader][SHUTDOWN` 日志。每次退出必须按同一 generation
+出现 `request`、`input-stop`、`trailing-stop`、`frame-pump-stop`、
+`connect-join`、`event-stop`、`drive-join`、`freerdp-disconnect`、`post-disconnect`、`context-free`、
+`complete`，并以 ArkTS `native-disconnect-return` 和 `arkts-return` 结束。
+
+| # | 场景 | 预期 | 实际 |
+|---|------|------|------|
+| 3.1.1 | 连接 2 分钟后正常退出 | 主界面立即可交互，无缺失 teardown 阶段 | ⬜ |
+| 3.1.2 | 持续鼠标与键盘输入时退出 | input worker 完成后才进入 FreeRDP disconnect | ⬜ |
+| 3.1.3 | 连接 30 分钟后退出 | 无 ANR/崩溃，所有 worker/context 释放 | ⬜ |
+| 3.1.4 | Home/前台恢复 10 次后退出 | renderer detach/restore 后 teardown 完整 | ⬜ |
+| 3.1.5 | 共享盘、音频、剪贴板分别开关 | connect/drive join 均有结束日志 | ⬜ |
+| 3.1.6 | 连续连接/断开 20 次 | 无残留 session、线程、renderer 或 audio | ⬜ |
+| 3.1.7 | 连接 2 小时后退出 | UI 不冻结，RSS/PSS 不持续线性增长 | ⬜ |
+
 ## R4: RustDesk 安全
 
 | # | 验证项 | 预期 | 实际 |

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -120,6 +120,7 @@ include_directories(
 # 原生单元测试 (纯 C++ 策略测试, 不依赖 OHOS NAPI/GL)
 # ============================================================
 option(RDP_BUILD_TESTS "Build lightweight native unit tests" OFF)
+option(RDP_TESTS_ONLY "Configure only lightweight native unit tests" OFF)
 if(RDP_BUILD_TESTS)
     add_executable(rdp_native_tests
         test/test_main.cpp
@@ -132,6 +133,7 @@ if(RDP_BUILD_TESTS)
         test/audio_queue_policy_test.cpp
         test/audio_activity_state_test.cpp
         test/rdp_frame_pump_contract_test.cpp
+        test/rdp_shutdown_state_test.cpp
         test/rdp_background_frame_cache_test.cpp
         test/rdp_certificate_policy_test.cpp
         test/rdp_auth_identity_policy_test.cpp
@@ -156,6 +158,14 @@ if(RDP_BUILD_TESTS)
     target_include_directories(rdp_native_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
+endif()
+
+if(RDP_TESTS_ONLY)
+    if(NOT RDP_BUILD_TESTS)
+        message(FATAL_ERROR "RDP_TESTS_ONLY requires RDP_BUILD_TESTS=ON")
+    endif()
+    message(STATUS "Configured lightweight native tests only")
+    return()
 endif()
 
 

--- a/entry/src/main/cpp/extensions/extension_loader_napi.cpp
+++ b/entry/src/main/cpp/extensions/extension_loader_napi.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cctype>
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <exception>
 #include <new>
@@ -809,6 +810,8 @@ napi_value NapiDisconnect(napi_env env, napi_callback_info info) {
 
     int32_t sessionId;
     napi_get_value_int32(env, args[0], &sessionId);
+    const auto shutdownStartedAt = std::chrono::steady_clock::now();
+    OH_LOG_INFO(LOG_APP, "[ExtLoader][SHUTDOWN] sessionId=%{public}d phase=napi-entry", sessionId);
 
     // 先清掉 SSH 数据回调 TSFN, 避免 reader 线程已停后还有 push 在排队
     {
@@ -827,6 +830,10 @@ napi_value NapiDisconnect(napi_env env, napi_callback_info info) {
 
     auto it = g_sessions.find(sessionId);
     if (it != g_sessions.end() && it->second->adapter) {
+        if (g_activeConnection == it->second->adapter) {
+            InputHandler::instance().setActiveAdapter(nullptr);
+            g_activeConnection = nullptr;
+        }
         it->second->adapter->disconnect();
     }
     g_sessions.erase(sessionId);
@@ -838,7 +845,11 @@ napi_value NapiDisconnect(napi_env env, napi_callback_info info) {
     }
     resetRemoteVideoActivity();
 
-    OH_LOG_INFO(LOG_APP, "[ExtLoader] 断开连接, sessionId=%{public}d", sessionId);
+    const auto shutdownElapsedUs = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - shutdownStartedAt).count();
+    OH_LOG_INFO(LOG_APP,
+        "[ExtLoader][SHUTDOWN] sessionId=%{public}d phase=napi-return elapsedUs=%{public}lld",
+        sessionId, static_cast<long long>(shutdownElapsedUs));
 
     napi_value undefined;
     napi_get_undefined(env, &undefined);
@@ -853,6 +864,7 @@ napi_value NapiDisconnect(napi_env env, napi_callback_info info) {
  */
 napi_value NapiDisconnectAll(napi_env env, napi_callback_info info) {
     (void)info;
+    const auto shutdownStartedAt = std::chrono::steady_clock::now();
 
     std::vector<std::shared_ptr<SessionContext>> sessions;
     sessions.reserve(g_sessions.size());
@@ -862,6 +874,8 @@ napi_value NapiDisconnectAll(napi_env env, napi_callback_info info) {
         }
     }
 
+    g_activeConnection = nullptr;
+    InputHandler::instance().setActiveAdapter(nullptr);
     for (const auto& session : sessions) {
         if (session->adapter) {
             session->adapter->disconnect();
@@ -869,13 +883,14 @@ napi_value NapiDisconnectAll(napi_env env, napi_callback_info info) {
     }
 
     g_sessions.clear();
-    g_activeConnection = nullptr;
-    InputHandler::instance().setActiveAdapter(nullptr);
     AudioPlayerNapi::DestroyActiveNative();
     resetRemoteVideoActivity();
 
-    OH_LOG_INFO(LOG_APP, "[ExtLoader] disconnectAll: closed %{public}zu session(s)",
-                sessions.size());
+    const auto shutdownElapsedUs = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - shutdownStartedAt).count();
+    OH_LOG_INFO(LOG_APP,
+        "[ExtLoader][SHUTDOWN] phase=disconnect-all-return sessions=%{public}zu elapsedUs=%{public}lld",
+        sessions.size(), static_cast<long long>(shutdownElapsedUs));
 
     napi_value undefined;
     napi_get_undefined(env, &undefined);

--- a/entry/src/main/cpp/rdp/freerdp_adapter.cpp
+++ b/entry/src/main/cpp/rdp/freerdp_adapter.cpp
@@ -21,6 +21,7 @@
 #include "rdp_performance_policy.h"
 #include "rdp_input_queue.h"
 #include "rdp_render_policy.h"
+#include "rdp_shutdown_state.h"
 #ifdef USE_REAL_FREERDP
 #include <freerdp/channels/rdpgfx.h>
 #include <freerdp/client/rdpgfx.h>
@@ -44,6 +45,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstring>
+#include <functional>
 #include <iomanip>
 #include <sstream>
 #include <thread>
@@ -514,6 +516,8 @@ static std::vector<UINT16> utf8ToUtf16(const std::string& text) {
     return result;
 }
 
+static std::atomic<uint64_t> g_nextRdpSessionGeneration {1};
+
 struct FreeRdpAdapter::Impl {
     TransferRuntimeStatus transferStatus;
     ConnectionConfig        config;
@@ -528,7 +532,12 @@ struct FreeRdpAdapter::Impl {
     pthread_t               driveThread = 0;
     std::mutex              stateMutex;
     std::mutex              instanceMutex;
+    std::mutex              shutdownMutex;
+    std::mutex              workerLifecycleMutex;
     std::mutex              renderMutex;
+    RdpShutdown::State      shutdownState;
+    std::atomic<uint64_t>   sessionGeneration {0};
+    std::atomic<int64_t>    shutdownStartedUs {0};
     RdpFramePump            framePump;
     std::atomic<bool>       backgroundVideoPrewarmEnabled {false};
     std::atomic<uint32_t>   backgroundVideoPrewarmIntervalMs {1000};
@@ -540,11 +549,11 @@ struct FreeRdpAdapter::Impl {
     uint64_t                inputQueueGeneration = 0;
     bool                    inputQueueRunning = false;
     bool                    inputQueueStop = false;
-    bool                    connecting = false;
-    bool                    connectThreadStarted = false;
-    bool                    driveThreadStarted = false;
-    bool                    stopRequested = false;
-    bool                    gdiInitialized = false;
+    std::atomic<bool>       connecting {false};
+    std::atomic<bool>       connectThreadStarted {false};
+    std::atomic<bool>       driveThreadStarted {false};
+    std::atomic<bool>       stopRequested {false};
+    std::atomic<bool>       gdiInitialized {false};
     uint32_t                driveDeviceId = 0;
     int                     paintCount = 0;
     int                     renderedPaintCount = 0;
@@ -574,6 +583,25 @@ struct FreeRdpAdapter::Impl {
     int                     trailingFrameHeight = 0;
     int                     trailingFrameStride = 0;
     int64_t                 trailingFrameDueUs = 0;
+
+    void beginShutdownTrace() {
+        shutdownStartedUs.store(steadyNowUs(), std::memory_order_release);
+        traceShutdown("request", "begin");
+    }
+
+    void traceShutdown(const char* phase, const char* result) const {
+        const int64_t startedUs = shutdownStartedUs.load(std::memory_order_acquire);
+        const int64_t elapsedUs = startedUs > 0 ? steadyNowUs() - startedUs : 0;
+        const uint64_t threadId = static_cast<uint64_t>(
+            std::hash<std::thread::id>{}(std::this_thread::get_id()));
+        OH_LOG_INFO(LOG_APP,
+            "[RDP-SHUTDOWN] generation=%{public}llu phase=%{public}s result=%{public}s elapsedUs=%{public}lld thread=%{public}llu",
+            static_cast<unsigned long long>(sessionGeneration.load(std::memory_order_acquire)),
+            phase ? phase : "unknown",
+            result ? result : "unknown",
+            static_cast<long long>(elapsedUs),
+            static_cast<unsigned long long>(threadId));
+    }
 
     void sendQueuedInputEvent(FreeRdpAdapter* owner, const RdpQueuedInputEvent& event,
                               uint64_t workerGeneration) {
@@ -794,6 +822,29 @@ struct FreeRdpAdapter::Impl {
             trailingFrameRequested = true;
         }
         trailingFrameCv.notify_one();
+    }
+
+    void startSessionWorkers(FreeRdpAdapter* owner) {
+        std::lock_guard<std::mutex> lifecycleLock(workerLifecycleMutex);
+        startInputQueueWorker(owner);
+        if (!framePump.start()) {
+            OH_LOG_WARN(LOG_APP, "[RDP] frame pump unavailable; falling back to direct render path");
+            return;
+        }
+        startTrailingFrameWorker();
+    }
+
+    void stopSessionWorkers() {
+        std::lock_guard<std::mutex> lifecycleLock(workerLifecycleMutex);
+        traceShutdown("input-stop", "begin");
+        stopInputQueueWorker();
+        traceShutdown("input-stop", "complete");
+        traceShutdown("trailing-stop", "begin");
+        stopTrailingFrameWorker();
+        traceShutdown("trailing-stop", "complete");
+        traceShutdown("frame-pump-stop", "begin");
+        framePump.stop();
+        traceShutdown("frame-pump-stop", "complete");
     }
 
     void setState(ConnectionState s, const std::string& msg = "") {
@@ -1298,7 +1349,7 @@ BOOL FreeRdpAdapter::cbPostConnect(freerdp* instance) {
 
     instance->update->BeginPaint = cbBeginPaint;
     instance->update->EndPaint = cbEndPaint;
-    self->impl_->gdiInitialized = true;
+    self->impl_->gdiInitialized.store(true, std::memory_order_release);
     self->impl_->paintCount = 0;
     self->impl_->renderedPaintCount = 0;
     self->impl_->skippedPaintCount = 0;
@@ -1310,12 +1361,7 @@ BOOL FreeRdpAdapter::cbPostConnect(freerdp* instance) {
     self->impl_->lastFrameWidth = 0;
     self->impl_->lastFrameHeight = 0;
     self->impl_->forceNextFullFrame = false;
-    self->impl_->startInputQueueWorker(self);
-    if (!self->impl_->framePump.start()) {
-        OH_LOG_WARN(LOG_APP, "[RDP] frame pump unavailable; falling back to direct render path");
-    } else {
-        self->impl_->startTrailingFrameWorker();
-    }
+    self->impl_->startSessionWorkers(self);
     OH_LOG_INFO(LOG_APP, "[RDP] GDI initialized: BGRA32 primary buffer ready");
     return TRUE;
 }
@@ -1326,14 +1372,14 @@ void FreeRdpAdapter::cbPostDisconnect(freerdp* instance) {
     auto* self = ctx ? ctx->adapter : nullptr;
     if (!self) return;
 
-    if (self->impl_->gdiInitialized && instance->context->gdi) {
-        self->impl_->stopInputQueueWorker();
-        self->impl_->stopTrailingFrameWorker();
-        self->impl_->framePump.stop();
+    self->impl_->traceShutdown("post-disconnect", "begin");
+    self->impl_->stopSessionWorkers();
+    if (self->impl_->gdiInitialized.exchange(false, std::memory_order_acq_rel) &&
+        instance->context->gdi) {
         gdi_free(instance);
-        self->impl_->gdiInitialized = false;
         OH_LOG_INFO(LOG_APP, "[RDP] GDI resources released");
     }
+    self->impl_->traceShutdown("post-disconnect", "complete");
 }
 
 BOOL FreeRdpAdapter::cbBeginPaint(rdpContext* context) {
@@ -1518,7 +1564,7 @@ BOOL FreeRdpAdapter::cbEndPaint(rdpContext* context) {
 
 // ---- 事件循环线程 ----
 void FreeRdpAdapter::startEventLoop() {
-    eventLoopRunning_ = true;
+    eventLoopRunning_.store(true, std::memory_order_release);
     const int rc = pthread_create(&impl_->eventThread, nullptr,
         [](void* arg) -> void* {
             auto* self = static_cast<FreeRdpAdapter*>(arg);
@@ -1526,23 +1572,27 @@ void FreeRdpAdapter::startEventLoop() {
             return nullptr;
         }, this);
     if (rc != 0) {
-        eventLoopRunning_ = false;
+        eventLoopRunning_.store(false, std::memory_order_release);
         impl_->eventThread = 0;
         OH_LOG_ERROR(LOG_APP, "[RDP] event loop pthread_create failed rc=%{public}d", rc);
     }
 }
 
 void FreeRdpAdapter::stopEventLoop() {
-    eventLoopRunning_ = false;
+    impl_->traceShutdown("event-stop", "begin");
+    eventLoopRunning_.store(false, std::memory_order_release);
     if (impl_->eventThread) {
-        pthread_join(impl_->eventThread, nullptr);
+        if (!pthread_equal(pthread_self(), impl_->eventThread)) {
+            pthread_join(impl_->eventThread, nullptr);
+        }
         impl_->eventThread = 0;
     }
+    impl_->traceShutdown("event-stop", "complete");
 }
 
 void FreeRdpAdapter::processEventLoop() {
     HANDLE handles[64];
-    while (eventLoopRunning_) {
+    while (eventLoopRunning_.load(std::memory_order_acquire)) {
         rdpContext* context = nullptr;
         {
             std::lock_guard<std::mutex> lock(impl_->instanceMutex);
@@ -1558,17 +1608,16 @@ void FreeRdpAdapter::processEventLoop() {
             continue;
         }
         DWORD ret = WaitForMultipleObjects(count, handles, FALSE, 100);
-        if (!eventLoopRunning_) {
+        if (!eventLoopRunning_.load(std::memory_order_acquire)) {
             break;
         }
         if (ret >= WAIT_OBJECT_0 && ret < WAIT_OBJECT_0 + count) {
-            std::lock_guard<std::mutex> lock(impl_->instanceMutex);
-            if (!eventLoopRunning_ || !instance_ || !instance_->context) {
+            if (!eventLoopRunning_.load(std::memory_order_acquire)) {
                 break;
             }
-            if (!freerdp_check_event_handles(instance_->context)) {
+            if (!freerdp_check_event_handles(context)) {
                 OH_LOG_WARN(LOG_APP, "[RDP] freerdp_check_event_handles returned false, stopping event loop");
-                eventLoopRunning_ = false;
+                eventLoopRunning_.store(false, std::memory_order_release);
                 break;
             }
         }
@@ -1577,27 +1626,35 @@ void FreeRdpAdapter::processEventLoop() {
 
 // ---- 构造/析构 ----
 void FreeRdpAdapter::joinConnectThread() {
+    impl_->traceShutdown("connect-join", "begin");
     if (!impl_->connectThreadStarted || !impl_->connectThread) {
+        impl_->traceShutdown("connect-join", "not-started");
         return;
     }
     if (pthread_equal(pthread_self(), impl_->connectThread)) {
+        impl_->traceShutdown("connect-join", "self-skip");
         return;
     }
     pthread_join(impl_->connectThread, nullptr);
     impl_->connectThread = 0;
     impl_->connectThreadStarted = false;
+    impl_->traceShutdown("connect-join", "complete");
 }
 
 void FreeRdpAdapter::joinDriveThread() {
+    impl_->traceShutdown("drive-join", "begin");
     if (!impl_->driveThreadStarted || !impl_->driveThread) {
+        impl_->traceShutdown("drive-join", "not-started");
         return;
     }
     if (pthread_equal(pthread_self(), impl_->driveThread)) {
+        impl_->traceShutdown("drive-join", "self-skip");
         return;
     }
     pthread_join(impl_->driveThread, nullptr);
     impl_->driveThread = 0;
     impl_->driveThreadStarted = false;
+    impl_->traceShutdown("drive-join", "complete");
 }
 
 struct RdpDriveMountRequest {
@@ -1647,15 +1704,21 @@ void FreeRdpAdapter::mountDriveAfterConnected(const std::string& driveName, cons
 
     uint32_t driveId = 0;
     UINT driveRc = ERROR_NOT_READY;
+    rdpContext* driveContext = nullptr;
     {
         std::lock_guard<std::mutex> lock(impl_->instanceMutex);
         if (impl_->stopRequested || !instance_ || !instance_->context) {
             OH_LOG_INFO(LOG_APP, "[RDP] redirected drive async mount skipped: instance unavailable");
             return;
         }
-        driveRc = freerdp_ohos_rdpdr_register_drive(instance_->context, driveName.c_str(),
-                                                    drivePath.c_str(), &driveId);
+        driveContext = instance_->context;
     }
+    if (impl_->stopRequested.load(std::memory_order_acquire)) {
+        OH_LOG_INFO(LOG_APP, "[RDP] redirected drive async mount skipped: shutdown requested");
+        return;
+    }
+    driveRc = freerdp_ohos_rdpdr_register_drive(driveContext, driveName.c_str(),
+                                                drivePath.c_str(), &driveId);
 
     if (driveRc == CHANNEL_RC_OK) {
         impl_->driveDeviceId = driveId;
@@ -1676,44 +1739,59 @@ void FreeRdpAdapter::mountDriveAfterConnected(const std::string& driveName, cons
 }
 
 void FreeRdpAdapter::abortActiveConnection() {
-    std::lock_guard<std::mutex> lock(impl_->instanceMutex);
-    if (!instance_) {
-        return;
+    rdpContext* context = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(impl_->instanceMutex);
+        context = instance_ ? instance_->context : nullptr;
     }
-    if (instance_->context) {
+    if (context) {
+        impl_->traceShutdown("connect-abort", "begin");
         OH_LOG_INFO(LOG_APP, "[RDP] abort active connection context");
-        freerdp_abort_connect_context(instance_->context);
+        freerdp_abort_connect_context(context);
+        impl_->traceShutdown("connect-abort", "complete");
     }
 }
 
 void FreeRdpAdapter::disconnectActiveInstance() {
-    std::lock_guard<std::mutex> lock(impl_->instanceMutex);
-    if (!instance_) {
+    freerdp* activeInstance = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(impl_->instanceMutex);
+        activeInstance = instance_;
+    }
+    if (!activeInstance) {
+        impl_->traceShutdown("freerdp-disconnect", "no-instance");
         return;
     }
-    if (instance_->context) {
-        freerdp_abort_connect_context(instance_->context);
+    impl_->traceShutdown("freerdp-disconnect", "begin");
+    if (activeInstance->context) {
+        freerdp_abort_connect_context(activeInstance->context);
     }
-    freerdp_disconnect(instance_);
+    freerdp_disconnect(activeInstance);
+    impl_->traceShutdown("freerdp-disconnect", "complete");
 }
 
 void FreeRdpAdapter::cleanupInstance() {
-    std::lock_guard<std::mutex> lock(impl_->instanceMutex);
-    if (!instance_) {
+    impl_->stopSessionWorkers();
+    freerdp* doomedInstance = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(impl_->instanceMutex);
+        doomedInstance = instance_;
+        instance_ = nullptr;
+    }
+    if (!doomedInstance) {
+        impl_->traceShutdown("context-free", "no-instance");
         return;
     }
-    if (impl_->gdiInitialized && instance_->context && instance_->context->gdi) {
-        impl_->stopInputQueueWorker();
-        impl_->stopTrailingFrameWorker();
-        impl_->framePump.stop();
-        gdi_free(instance_);
-        impl_->gdiInitialized = false;
+    impl_->traceShutdown("context-free", "begin");
+    if (impl_->gdiInitialized.exchange(false, std::memory_order_acq_rel) &&
+        doomedInstance->context && doomedInstance->context->gdi) {
+        gdi_free(doomedInstance);
     }
-    if (instance_->context) {
-        freerdp_context_free(instance_);
+    if (doomedInstance->context) {
+        freerdp_context_free(doomedInstance);
     }
-    freerdp_free(instance_);
-    instance_ = nullptr;
+    freerdp_free(doomedInstance);
+    impl_->traceShutdown("context-free", "complete");
 }
 
 FreeRdpAdapter::FreeRdpAdapter() : impl_(std::make_unique<Impl>()) {
@@ -1734,6 +1812,14 @@ std::string FreeRdpAdapter::protocolVersion() { return FREERDP_VERSION_FULL; }
 // ---- 连接管理 (异步, 不阻塞 NAPI 线程) ----
 int FreeRdpAdapter::connect(const ConnectionConfig& cfg) {
     if (impl_->state == ConnectionState::CONNECTED || impl_->connecting) { disconnect(); }
+    {
+        std::lock_guard<std::mutex> shutdownLock(impl_->shutdownMutex);
+        impl_->shutdownState.reset();
+        impl_->sessionGeneration.store(
+            g_nextRdpSessionGeneration.fetch_add(1, std::memory_order_relaxed),
+            std::memory_order_release);
+        impl_->shutdownStartedUs.store(0, std::memory_order_release);
+    }
     impl_->config = cfg;
     impl_->connecting = true;
     impl_->stopRequested = false;
@@ -1786,6 +1872,12 @@ void FreeRdpAdapter::connectThreadFunc() {
     }
     auto* ctx = reinterpret_cast<FreeRdpContext*>(instance_->context);
     ctx->adapter = this;
+    if (impl_->stopRequested.load(std::memory_order_acquire)) {
+        impl_->traceShutdown("connect-cancel", "after-context");
+        cleanupInstance();
+        impl_->connecting = false;
+        return;
+    }
 
     int port = cfg.port > 0 ? cfg.port : RDP_TCP_PORT;
 
@@ -1988,6 +2080,12 @@ void FreeRdpAdapter::connectThreadFunc() {
                 freerdp_settings_get_uint32(s, FreeRDP_DynamicChannelCount));
 
     // ---- 执行连接 ----
+    if (impl_->stopRequested.load(std::memory_order_acquire)) {
+        impl_->traceShutdown("connect-cancel", "before-connect");
+        cleanupInstance();
+        impl_->connecting = false;
+        return;
+    }
     OH_LOG_INFO(LOG_APP, "[RDP] 开始 freerdp_connect...");
     BOOL ok = freerdp_connect(instance_);
     if (!ok) {
@@ -2026,23 +2124,28 @@ void FreeRdpAdapter::connectThreadFunc() {
 }
 
 void FreeRdpAdapter::disconnect() {
-    const bool wasConnecting = impl_->connecting && impl_->connectThreadStarted;
-    impl_->stopRequested = true;
-
-    if (wasConnecting) {
-        abortActiveConnection();
-        joinConnectThread();
-        joinDriveThread();
-        if (impl_->state == ConnectionState::CONNECTED) {
-            stopEventLoop();
-            disconnectActiveInstance();
-        }
-    } else {
-        joinDriveThread();
-        stopEventLoop();
-        disconnectActiveInstance();
-        joinConnectThread();
+    std::lock_guard<std::mutex> shutdownLock(impl_->shutdownMutex);
+    if (!impl_->shutdownState.requestDisconnect()) {
+        impl_->traceShutdown("request", "duplicate");
+        return;
     }
+    impl_->beginShutdownTrace();
+    impl_->stopRequested.store(true, std::memory_order_release);
+
+    impl_->stopSessionWorkers();
+    abortActiveConnection();
+
+    // The connect thread can start both event and drive workers. Join the producer
+    // first so no worker can appear after the corresponding stop/join returns.
+    joinConnectThread();
+    stopEventLoop();
+    joinDriveThread();
+
+    impl_->shutdownState.advance(RdpShutdown::Phase::Quiescing,
+                                 RdpShutdown::Phase::TransportDisconnecting);
+    disconnectActiveInstance();
+    impl_->shutdownState.advance(RdpShutdown::Phase::TransportDisconnecting,
+                                 RdpShutdown::Phase::Releasing);
     impl_->connecting = false;
     cleanupInstance();
     {
@@ -2054,6 +2157,9 @@ void FreeRdpAdapter::disconnect() {
         impl_->state != ConnectionState::ERROR) {
         impl_->setState(ConnectionState::DISCONNECTED, "Disconnected");
     }
+    impl_->shutdownState.advance(RdpShutdown::Phase::Releasing,
+                                 RdpShutdown::Phase::Complete);
+    impl_->traceShutdown("complete", "success");
     OH_LOG_INFO(LOG_APP, "[RDP] FreeRDP session disconnected/cleaned");
     return;
 #if 0

--- a/entry/src/main/cpp/rdp/freerdp_adapter.h
+++ b/entry/src/main/cpp/rdp/freerdp_adapter.h
@@ -10,6 +10,7 @@
 #define FREERDP_ADAPTER_H
 
 #include "extensions/protocol_adapter.h"
+#include <atomic>
 #include <memory>
 #ifdef USE_REAL_FREERDP
 #include <freerdp/freerdp.h>
@@ -85,7 +86,7 @@ private:
 #ifdef USE_REAL_FREERDP
     // FreeRDP 客户端实例 + 事件循环
     freerdp*  instance_ = nullptr;
-    bool      eventLoopRunning_ = false;
+    std::atomic<bool> eventLoopRunning_ {false};
 
     void startEventLoop();
     void stopEventLoop();

--- a/entry/src/main/cpp/rdp/rdp_shutdown_state.h
+++ b/entry/src/main/cpp/rdp/rdp_shutdown_state.h
@@ -1,0 +1,93 @@
+/**
+ * rdp_shutdown_state.h - RDP teardown state and lock-order contract
+ */
+
+#ifndef RDP_SHUTDOWN_STATE_H
+#define RDP_SHUTDOWN_STATE_H
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+
+namespace RdpShutdown {
+
+enum class Phase : std::uint8_t {
+    Running = 0,
+    Quiescing,
+    TransportDisconnecting,
+    Releasing,
+    Complete,
+};
+
+enum class Action : std::uint8_t {
+    RejectNewWork = 0,
+    JoinInputWorker,
+    JoinPresentationWorker,
+    JoinEventWorker,
+    JoinDriveWorker,
+    JoinConnectWorker,
+    DisconnectTransport,
+    ReleaseInstance,
+};
+
+constexpr std::array<Action, 8> OrderedActions() {
+    return {
+        Action::RejectNewWork,
+        Action::JoinInputWorker,
+        Action::JoinPresentationWorker,
+        Action::JoinConnectWorker,
+        Action::JoinEventWorker,
+        Action::JoinDriveWorker,
+        Action::DisconnectTransport,
+        Action::ReleaseInstance,
+    };
+}
+
+constexpr bool RequiresInstanceMutexReleased(Action action) {
+    return action != Action::RejectNewWork;
+}
+
+constexpr bool CanRun(Action action, bool instanceMutexHeld) {
+    return !RequiresInstanceMutexReleased(action) || !instanceMutexHeld;
+}
+
+constexpr bool IsForwardTransition(Phase from, Phase to) {
+    return (from == Phase::Running && to == Phase::Quiescing) ||
+        (from == Phase::Quiescing && to == Phase::TransportDisconnecting) ||
+        (from == Phase::TransportDisconnecting && to == Phase::Releasing) ||
+        (from == Phase::Releasing && to == Phase::Complete);
+}
+
+class State {
+public:
+    Phase phase() const {
+        return phase_.load(std::memory_order_acquire);
+    }
+
+    bool requestDisconnect() {
+        Phase expected = Phase::Running;
+        return phase_.compare_exchange_strong(expected, Phase::Quiescing,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire);
+    }
+
+    bool advance(Phase expected, Phase next) {
+        if (!IsForwardTransition(expected, next)) {
+            return false;
+        }
+        return phase_.compare_exchange_strong(expected, next,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire);
+    }
+
+    void reset() {
+        phase_.store(Phase::Running, std::memory_order_release);
+    }
+
+private:
+    std::atomic<Phase> phase_ {Phase::Running};
+};
+
+} // namespace RdpShutdown
+
+#endif // RDP_SHUTDOWN_STATE_H

--- a/entry/src/main/cpp/test/rdp_shutdown_state_test.cpp
+++ b/entry/src/main/cpp/test/rdp_shutdown_state_test.cpp
@@ -1,0 +1,51 @@
+/**
+ * rdp_shutdown_state_test.cpp - deterministic RDP teardown ordering contracts
+ */
+
+#include "test_runner.h"
+#include "rdp/rdp_shutdown_state.h"
+
+using RdpShutdown::Action;
+using RdpShutdown::Phase;
+
+RDP_TEST_CASE(rdp_shutdown_state_advances_once_and_rejects_regression) {
+    RdpShutdown::State state;
+    RDP_ASSERT_EQ(state.phase(), Phase::Running);
+    RDP_ASSERT(state.requestDisconnect());
+    RDP_ASSERT_EQ(state.phase(), Phase::Quiescing);
+    RDP_ASSERT(!state.requestDisconnect());
+    RDP_ASSERT(state.advance(Phase::Quiescing, Phase::TransportDisconnecting));
+    RDP_ASSERT(!state.advance(Phase::TransportDisconnecting, Phase::Quiescing));
+    RDP_ASSERT(state.advance(Phase::TransportDisconnecting, Phase::Releasing));
+    RDP_ASSERT(state.advance(Phase::Releasing, Phase::Complete));
+}
+
+RDP_TEST_CASE(rdp_shutdown_actions_never_run_under_instance_mutex) {
+    constexpr Action actions[] = {
+        Action::JoinInputWorker,
+        Action::JoinPresentationWorker,
+        Action::JoinEventWorker,
+        Action::JoinDriveWorker,
+        Action::JoinConnectWorker,
+        Action::DisconnectTransport,
+        Action::ReleaseInstance,
+    };
+    for (const Action action : actions) {
+        RDP_ASSERT(RdpShutdown::RequiresInstanceMutexReleased(action));
+        RDP_ASSERT(!RdpShutdown::CanRun(action, true));
+        RDP_ASSERT(RdpShutdown::CanRun(action, false));
+    }
+}
+
+RDP_TEST_CASE(rdp_shutdown_sequence_quiesces_workers_before_transport) {
+    constexpr auto sequence = RdpShutdown::OrderedActions();
+    RDP_ASSERT_EQ(sequence[0], Action::RejectNewWork);
+    RDP_ASSERT_EQ(sequence[1], Action::JoinInputWorker);
+    RDP_ASSERT_EQ(sequence[2], Action::JoinPresentationWorker);
+    // The connect thread can create event and drive workers, so its producer must stop first.
+    RDP_ASSERT_EQ(sequence[3], Action::JoinConnectWorker);
+    RDP_ASSERT_EQ(sequence[4], Action::JoinEventWorker);
+    RDP_ASSERT_EQ(sequence[5], Action::JoinDriveWorker);
+    RDP_ASSERT_EQ(sequence[6], Action::DisconnectTransport);
+    RDP_ASSERT_EQ(sequence[7], Action::ReleaseInstance);
+}

--- a/entry/src/main/ets/pages/RemoteDesktop.ets
+++ b/entry/src/main/ets/pages/RemoteDesktop.ets
@@ -2615,6 +2615,7 @@ struct RemoteDesktop {
       return;
     }
     this.cleanupStarted = true;
+    const cleanupStartedAtMs: number = Date.now();
     if (shouldRestoreRemoteNavigation(reason, false)) {
       this.setRemoteNavigationHidden(false, reason);
     }
@@ -2623,7 +2624,8 @@ struct RemoteDesktop {
     this.activeSessionRegistry.clear(reason);
     this.clearRdpRenderWatchdog();
     this.clearRdpNativeStateMonitor();
-    hilog.info(RD_DOMAIN, RD_TAG, 'disconnectAndCleanup: reason=' + reason);
+    hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=arkts-entry reason=' + reason +
+      ' sessionId=' + this.sessionId.toString());
     // T-171: 断开时隐藏胶囊和面板 + 释放所有修饰键
     this.handleVisible = false;
     this.modifierPanelMounted = false;
@@ -2647,7 +2649,12 @@ struct RemoteDesktop {
       if (this.sessionId > 0) {
         this.disableRdpBackgroundVideoPrewarm('disconnect-cleanup');
         this.flushMouseMove();
+        const nativeDisconnectStartedAtMs: number = Date.now();
+        hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=native-disconnect-begin sessionId=' +
+          this.sessionId.toString());
         this.loader.disconnect();
+        hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=native-disconnect-return elapsedMs=' +
+          (Date.now() - nativeDisconnectStartedAtMs).toString());
         this.sessionId = -1;
         this.nativeHandles.markProtocolDisconnected();
       }
@@ -2656,9 +2663,13 @@ struct RemoteDesktop {
         this.decoderHandle = -1;
       }
       if (this.rendererHandle > 0) {
+        const rendererDestroyStartedAtMs: number = Date.now();
+        hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=renderer-destroy-begin');
         this.markXComponentSurfaceDetached('disconnectAndCleanup');
         this.loader.destroyRenderer();
         this.rendererHandle = -1;
+        hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=renderer-destroy-return elapsedMs=' +
+          (Date.now() - rendererDestroyStartedAtMs).toString());
       }
       this.loader.destroyAudioPlayer();
       this.clearFileTransferAutoHide();
@@ -2694,8 +2705,11 @@ struct RemoteDesktop {
       }
       this.connected = false;
       this.connectStarted = false;
+      hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=arkts-return elapsedMs=' +
+        (Date.now() - cleanupStartedAtMs).toString());
     } catch (err) {
-      // 清理阶段忽略异常
+      hilog.error(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=arkts-error elapsedMs=' +
+        (Date.now() - cleanupStartedAtMs).toString() + ' err=' + JSON.stringify(err));
     }
   }
 


### PR DESCRIPTION
## Summary
- add a monotonic RDP shutdown contract and focused native tests
- remove FreeRDP callbacks, joins, disconnect and instance release from the instance mutex critical section
- serialize worker teardown and add ArkTS/NAPI/native phase timing logs
- document the long-session exit verification matrix

## Verification
- native tests: 78 passed, 0 failed
- default@OhosTestCompileArkTS: passed
- assembleHap: passed for arm64-v8a and x86_64
- open-source compliance Light gate: passed
- emulator install/launch: passed
- real RDP login-failure cleanup: native complete in 206 us, NAPI returned in 177744 us, ArkTS cleanup returned in 1 ms, host list responsive

## Remaining device gate
- successful connected-session soak at 2 min / 30 min / 2 h and 20 reconnect loops requires valid test credentials and is tracked as the next phase