### PR TITLE
fix(rdp): make long-session teardown non-blocking

### DIFF
--- a/docs/DEVICE_VERIFICATION_CHECKLIST.md
+++ b/docs/DEVICE_VERIFICATION_CHECKLIST.md
@@ -52,7 +52,8 @@ hdc hilog | grep -E "RDP_NAPI|GL_RENDERER|HW_DECODER|RDP_ADAPTER|RUSTDESK|AUDIO|
 采集 `RDP-SHUTDOWN` 与 `ExtLoader][SHUTDOWN` 日志。每次退出必须按同一 generation
 出现 `request`、`input-stop`、`trailing-stop`、`frame-pump-stop`、
 `connect-join`、`event-stop`、`drive-join`、`freerdp-disconnect`、`post-disconnect`、`context-free`、
-`complete`，并以 ArkTS `native-disconnect-return` 和 `arkts-return` 结束。
+`complete`，随后出现 executor 的 `decoder-destroy`、`renderer-destroy`、`audio-destroy`
+与 `executor-return`。ArkTS `native-disconnect-return` 必须先返回且不等待上述后台阶段。
 
 | # | 场景 | 预期 | 实际 |
 |---|------|------|------|

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -24,6 +24,7 @@ set(COMMON_SOURCES
 # -- 扩展框架 --
 set(EXTENSION_SOURCES
     extensions/extension_loader_napi.cpp
+    extensions/session_teardown_executor.cpp
 )
 
 # -- 协议适配器 --
@@ -134,6 +135,7 @@ if(RDP_BUILD_TESTS)
         test/audio_activity_state_test.cpp
         test/rdp_frame_pump_contract_test.cpp
         test/rdp_shutdown_state_test.cpp
+        test/session_teardown_executor_test.cpp
         test/rdp_background_frame_cache_test.cpp
         test/rdp_certificate_policy_test.cpp
         test/rdp_auth_identity_policy_test.cpp
@@ -154,6 +156,7 @@ if(RDP_BUILD_TESTS)
         video/video_activity_state.cpp
         render/video_backpressure_controller.cpp
         render/video_perf_counters.cpp
+        extensions/session_teardown_executor.cpp
     )
     target_include_directories(rdp_native_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/entry/src/main/cpp/audio/audio_player.cpp
+++ b/entry/src/main/cpp/audio/audio_player.cpp
@@ -567,16 +567,39 @@ int AudioPlayerNapi::DispatchActiveNative(const uint8_t* data, size_t size, int 
 }
 
 void AudioPlayerNapi::DestroyActiveNative() {
+    std::shared_ptr<AudioPlayer> player = TakeActiveNative();
+    if (player) {
+        player->Destroy();
+    }
+}
+
+std::shared_ptr<AudioPlayer> AudioPlayerNapi::TakeActiveNative() {
     std::shared_ptr<AudioPlayer> player;
     {
         std::lock_guard<std::mutex> lock(g_activeAudioMutex);
         player = g_activeAudioPlayer;
         g_activeAudioPlayer = nullptr;
     }
-    if (player) {
-        player->Destroy();
-    }
     g_audioActivityState.reset();
+    return player;
+}
+
+void AudioPlayerNapi::DestroyDetachedNative(
+    int64_t handle, std::shared_ptr<AudioPlayer> activePlayer) {
+    std::shared_ptr<AudioPlayer> handlePlayer;
+    if (handle > 0) {
+        auto* ctx = reinterpret_cast<AudioPlayerContext*>(handle);
+        if (ctx) {
+            handlePlayer = ctx->player;
+            delete ctx;
+        }
+    }
+    if (handlePlayer) {
+        handlePlayer->Destroy();
+    }
+    if (activePlayer && activePlayer != handlePlayer) {
+        activePlayer->Destroy();
+    }
 }
 
 bool AudioPlayerNapi::IsActivePlaybackReceiving() {

--- a/entry/src/main/cpp/audio/audio_player.h
+++ b/entry/src/main/cpp/audio/audio_player.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <functional>
 #include <mutex>
+#include <memory>
 #include <string>
 #include <vector>
 #include <ohaudio/native_audiostream_base.h>
@@ -129,6 +130,8 @@ namespace AudioPlayerNapi {
     napi_value Init(napi_env env, napi_value exports);
     int DispatchActiveNative(const uint8_t* data, size_t size, int sampleRate, int channels);
     void DestroyActiveNative();
+    std::shared_ptr<AudioPlayer> TakeActiveNative();
+    void DestroyDetachedNative(int64_t handle, std::shared_ptr<AudioPlayer> activePlayer);
     bool IsActivePlaybackReceiving();
     bool IsActiveAudioMuted();
     void SetActiveAudioMuted(bool muted);

--- a/entry/src/main/cpp/extensions/extension_loader_napi.cpp
+++ b/entry/src/main/cpp/extensions/extension_loader_napi.cpp
@@ -7,6 +7,7 @@
 
 #include "extension_registry.h"
 #include "protocol_adapter.h"
+#include "session_teardown_executor.h"
 #include "rdp/freerdp_adapter.h"
 #include "ssh/ssh_adapter.h"
 #include "ssh/ssh_key_tool.h"
@@ -30,6 +31,7 @@
 #include <cstring>
 #include <exception>
 #include <new>
+#include <stdexcept>
 #include <vector>
 
 #ifdef RUSTDESK_USE_REAL_CORE
@@ -62,13 +64,25 @@ static std::shared_ptr<ProtocolAdapter> g_activeConnection = nullptr;
 
 // 连接会话上下文
 struct SessionContext {
+    enum class Lifecycle : uint8_t {
+        Active = 0,
+        Disconnecting,
+        Complete,
+        Failed,
+    };
+
     std::shared_ptr<ProtocolAdapter> adapter;
     std::string protocolName;
     std::string lastStateMessage;
     std::mutex messageMutex;
+    std::atomic<Lifecycle> lifecycle {Lifecycle::Active};
+    std::atomic<uint64_t> teardownRequestId {0};
 };
 
 static std::map<int, std::shared_ptr<SessionContext>> g_sessions;
+static std::map<int, uint64_t> g_disconnectRequestBySession;
+static SessionTeardown::Executor g_teardownExecutor;
+static uint64_t g_disconnectAllRequestId = 0;
 static int g_nextSessionId = 1;
 static std::atomic<uint64_t> g_napiWheelSendCount {0};
 static std::atomic<uint64_t> g_napiTextSendCount {0};
@@ -684,6 +698,20 @@ napi_value NapiConnect(napi_env env, napi_callback_info info) {
     session->protocolName = protocolName;
 
     int sessionId = g_nextSessionId++;
+    g_disconnectAllRequestId = 0;
+    if (g_disconnectRequestBySession.size() > 256) {
+        for (auto it = g_disconnectRequestBySession.begin();
+             it != g_disconnectRequestBySession.end();) {
+            const SessionTeardown::State state = g_teardownExecutor.state(it->second);
+            if (state == SessionTeardown::State::Complete ||
+                state == SessionTeardown::State::Failed ||
+                state == SessionTeardown::State::Unknown) {
+                it = g_disconnectRequestBySession.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
     g_sessions[sessionId] = session;
     g_activeConnection = adapter;
 
@@ -800,16 +828,148 @@ napi_value NapiConnect(napi_env env, napi_callback_info info) {
     return result;
 }
 
+struct TeardownNativeResources {
+    int64_t rendererHandle = -1;
+    int64_t decoderHandle = -1;
+    int64_t audioHandle = -1;
+    std::shared_ptr<AudioPlayer> activeAudioPlayer;
+};
+
+static int64_t GetOptionalHandle(napi_env env, size_t argc, napi_value* args, size_t index) {
+    int64_t handle = -1;
+    if (index < argc) {
+        napi_get_value_int64(env, args[index], &handle);
+    }
+    return handle;
+}
+
+static void DeactivateNativeResources(TeardownNativeResources& resources) {
+    RendererNapi::DeactivateRenderer(resources.rendererHandle);
+    DecoderNapi::DeactivateDecoder(resources.decoderHandle);
+    resources.activeAudioPlayer = AudioPlayerNapi::TakeActiveNative();
+    resetRemoteVideoActivity();
+}
+
+static void DestroyNativeResources(TeardownNativeResources resources) {
+    OH_LOG_INFO(LOG_APP, "[ExtLoader][SHUTDOWN] phase=decoder-destroy-begin");
+    DecoderNapi::DestroyDecoderHandle(resources.decoderHandle);
+    OH_LOG_INFO(LOG_APP, "[ExtLoader][SHUTDOWN] phase=decoder-destroy-return");
+    OH_LOG_INFO(LOG_APP, "[ExtLoader][SHUTDOWN] phase=renderer-destroy-begin");
+    RendererNapi::DestroyRendererHandle(resources.rendererHandle);
+    OH_LOG_INFO(LOG_APP, "[ExtLoader][SHUTDOWN] phase=renderer-destroy-return");
+    OH_LOG_INFO(LOG_APP, "[ExtLoader][SHUTDOWN] phase=audio-destroy-begin");
+    AudioPlayerNapi::DestroyDetachedNative(
+        resources.audioHandle, std::move(resources.activeAudioPlayer));
+    OH_LOG_INFO(LOG_APP, "[ExtLoader][SHUTDOWN] phase=audio-destroy-return");
+}
+
+static void PrepareAdapterForTeardown(const std::shared_ptr<ProtocolAdapter>& adapter) {
+    if (!adapter) {
+        return;
+    }
+    adapter->setVideoCallback(nullptr);
+    adapter->setAudioCallback(nullptr);
+}
+
+static bool HasNativeResources(const TeardownNativeResources& resources) {
+    return resources.rendererHandle > 0 || resources.decoderHandle > 0 ||
+        resources.audioHandle > 0;
+}
+
+static uint64_t BeginSessionTeardown(
+    int32_t sessionId, TeardownNativeResources resources) {
+    if (sessionId > 0) {
+        const auto existing = g_disconnectRequestBySession.find(sessionId);
+        if (existing != g_disconnectRequestBySession.end()) {
+            return existing->second;
+        }
+    }
+
+    auto it = g_sessions.find(sessionId);
+    if (it == g_sessions.end() || !it->second) {
+        if (!HasNativeResources(resources)) {
+            return 0;
+        }
+        DeactivateNativeResources(resources);
+        auto resourceTask = [resources = std::move(resources)]() mutable {
+            DestroyNativeResources(std::move(resources));
+        };
+        const uint64_t resourceRequestId = g_teardownExecutor.enqueue(resourceTask);
+        if (resourceRequestId == 0) {
+            resourceTask();
+        }
+        return resourceRequestId;
+    }
+    const std::shared_ptr<SessionContext> session = it->second;
+    SessionContext::Lifecycle expected = SessionContext::Lifecycle::Active;
+    if (!session->lifecycle.compare_exchange_strong(
+            expected, SessionContext::Lifecycle::Disconnecting)) {
+        return session->teardownRequestId.load(std::memory_order_acquire);
+    }
+
+    const std::shared_ptr<ProtocolAdapter> adapter = session->adapter;
+    PrepareAdapterForTeardown(adapter);
+    if (g_activeConnection == adapter) {
+        InputHandler::instance().setActiveAdapter(nullptr);
+        g_activeConnection = nullptr;
+    }
+    DeactivateNativeResources(resources);
+    g_sessions.erase(it);
+
+    auto task = [sessionId, session, adapter, resources = std::move(resources)]() mutable {
+        const auto startedAt = std::chrono::steady_clock::now();
+        OH_LOG_INFO(LOG_APP,
+            "[ExtLoader][SHUTDOWN] sessionId=%{public}d phase=executor-start",
+            sessionId);
+        bool failed = false;
+        try {
+            if (adapter) {
+                adapter->disconnect();
+            }
+        } catch (...) {
+            failed = true;
+        }
+        try {
+            DestroyNativeResources(std::move(resources));
+        } catch (...) {
+            failed = true;
+        }
+        session->adapter.reset();
+        session->lifecycle.store(
+            failed ? SessionContext::Lifecycle::Failed : SessionContext::Lifecycle::Complete,
+            std::memory_order_release);
+        const auto elapsedUs = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - startedAt).count();
+        OH_LOG_INFO(LOG_APP,
+            "[ExtLoader][SHUTDOWN] sessionId=%{public}d phase=executor-return result=%{public}s elapsedUs=%{public}lld",
+            sessionId, failed ? "failed" : "complete", static_cast<long long>(elapsedUs));
+        if (failed) {
+            throw std::runtime_error("session teardown failed");
+        }
+    };
+
+    uint64_t requestId = g_teardownExecutor.enqueue(task);
+    if (requestId == 0) {
+        task();
+        return 0;
+    }
+    session->teardownRequestId.store(requestId, std::memory_order_release);
+    g_disconnectRequestBySession[sessionId] = requestId;
+    return requestId;
+}
+
 /**
- * NAPI: disconnect(sessionId: number): void
+ * NAPI: beginDisconnect(sessionId, rendererHandle, decoderHandle, audioHandle): number
  */
 napi_value NapiDisconnect(napi_env env, napi_callback_info info) {
-    size_t argc = 1;
-    napi_value args[1];
+    size_t argc = 4;
+    napi_value args[4];
     napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
 
-    int32_t sessionId;
-    napi_get_value_int32(env, args[0], &sessionId);
+    int32_t sessionId = -1;
+    if (argc > 0) {
+        napi_get_value_int32(env, args[0], &sessionId);
+    }
     const auto shutdownStartedAt = std::chrono::steady_clock::now();
     OH_LOG_INFO(LOG_APP, "[ExtLoader][SHUTDOWN] sessionId=%{public}d phase=napi-entry", sessionId);
 
@@ -828,73 +988,149 @@ napi_value NapiDisconnect(napi_env env, napi_callback_info info) {
         }
     }
 
-    auto it = g_sessions.find(sessionId);
-    if (it != g_sessions.end() && it->second->adapter) {
-        if (g_activeConnection == it->second->adapter) {
-            InputHandler::instance().setActiveAdapter(nullptr);
-            g_activeConnection = nullptr;
-        }
-        it->second->adapter->disconnect();
-    }
-    g_sessions.erase(sessionId);
-    AudioPlayerNapi::DestroyActiveNative();
-
-    if (g_activeConnection && g_sessions.empty()) {
-        g_activeConnection = nullptr;
-        InputHandler::instance().setActiveAdapter(nullptr);
-    }
-    resetRemoteVideoActivity();
+    TeardownNativeResources resources;
+    resources.rendererHandle = GetOptionalHandle(env, argc, args, 1);
+    resources.decoderHandle = GetOptionalHandle(env, argc, args, 2);
+    resources.audioHandle = GetOptionalHandle(env, argc, args, 3);
+    const uint64_t requestId = BeginSessionTeardown(sessionId, std::move(resources));
 
     const auto shutdownElapsedUs = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - shutdownStartedAt).count();
     OH_LOG_INFO(LOG_APP,
-        "[ExtLoader][SHUTDOWN] sessionId=%{public}d phase=napi-return elapsedUs=%{public}lld",
-        sessionId, static_cast<long long>(shutdownElapsedUs));
+        "[ExtLoader][SHUTDOWN] sessionId=%{public}d requestId=%{public}llu phase=napi-return elapsedUs=%{public}lld",
+        sessionId, static_cast<unsigned long long>(requestId),
+        static_cast<long long>(shutdownElapsedUs));
 
-    napi_value undefined;
-    napi_get_undefined(env, &undefined);
-    return undefined;
+    napi_value result;
+    napi_create_int64(env, static_cast<int64_t>(requestId), &result);
+    return result;
 }
 
 /**
- * NAPI: disconnectAll(): void
+ * NAPI: disconnectAll(rendererHandle, decoderHandle, audioHandle): number
  *
  * Ability 退后台/销毁时兜底释放所有协议会话。RDP 如果只靠页面 aboutToDisappear,
  * 在系统手势回桌面或后台清理时可能来不及触发, Windows 侧会保留会话。
  */
 napi_value NapiDisconnectAll(napi_env env, napi_callback_info info) {
-    (void)info;
+    size_t argc = 3;
+    napi_value args[3];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
     const auto shutdownStartedAt = std::chrono::steady_clock::now();
 
-    std::vector<std::shared_ptr<SessionContext>> sessions;
+    const SessionTeardown::State existingState =
+        g_teardownExecutor.state(g_disconnectAllRequestId);
+    if (g_disconnectAllRequestId > 0 &&
+        (existingState == SessionTeardown::State::Queued ||
+         existingState == SessionTeardown::State::Running)) {
+        napi_value existingResult;
+        napi_create_int64(env, static_cast<int64_t>(g_disconnectAllRequestId), &existingResult);
+        return existingResult;
+    }
+
+    std::vector<std::pair<int, std::shared_ptr<SessionContext>>> sessions;
     sessions.reserve(g_sessions.size());
     for (const auto& item : g_sessions) {
         if (item.second) {
-            sessions.push_back(item.second);
+            sessions.push_back(item);
         }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_dataTsfnMutex);
+        for (const auto& entry : g_dataTsfnMap) {
+            const auto sessionIt = g_sessions.find(entry.first);
+            if (sessionIt != g_sessions.end() && sessionIt->second &&
+                sessionIt->second->adapter) {
+                const auto sshAdapter =
+                    std::dynamic_pointer_cast<SshAdapter>(sessionIt->second->adapter);
+                if (sshAdapter) {
+                    sshAdapter->setOnDataCallback(nullptr);
+                }
+            }
+            napi_release_threadsafe_function(entry.second, napi_tsfn_release);
+        }
+        g_dataTsfnMap.clear();
     }
 
     g_activeConnection = nullptr;
     InputHandler::instance().setActiveAdapter(nullptr);
-    for (const auto& session : sessions) {
-        if (session->adapter) {
-            session->adapter->disconnect();
+    for (const auto& item : sessions) {
+        item.second->lifecycle.store(SessionContext::Lifecycle::Disconnecting,
+                                     std::memory_order_release);
+        PrepareAdapterForTeardown(item.second->adapter);
+    }
+    g_sessions.clear();
+
+    TeardownNativeResources resources;
+    resources.rendererHandle = GetOptionalHandle(env, argc, args, 0);
+    resources.decoderHandle = GetOptionalHandle(env, argc, args, 1);
+    resources.audioHandle = GetOptionalHandle(env, argc, args, 2);
+    DeactivateNativeResources(resources);
+
+    auto task = [sessions, resources = std::move(resources)]() mutable {
+        bool failed = false;
+        for (const auto& item : sessions) {
+            const std::shared_ptr<SessionContext>& session = item.second;
+            bool sessionFailed = false;
+            try {
+                if (session->adapter) {
+                    session->adapter->disconnect();
+                }
+            } catch (...) {
+                failed = true;
+                sessionFailed = true;
+            }
+            session->adapter.reset();
+            session->lifecycle.store(
+                sessionFailed ? SessionContext::Lifecycle::Failed : SessionContext::Lifecycle::Complete,
+                std::memory_order_release);
+        }
+        try {
+            DestroyNativeResources(std::move(resources));
+        } catch (...) {
+            failed = true;
+        }
+        if (failed) {
+            throw std::runtime_error("disconnectAll teardown failed");
+        }
+    };
+
+    const uint64_t requestId = g_teardownExecutor.enqueue(task);
+    if (requestId == 0) {
+        task();
+    } else {
+        g_disconnectAllRequestId = requestId;
+        for (const auto& item : sessions) {
+            item.second->teardownRequestId.store(requestId, std::memory_order_release);
+            g_disconnectRequestBySession[item.first] = requestId;
         }
     }
-
-    g_sessions.clear();
-    AudioPlayerNapi::DestroyActiveNative();
-    resetRemoteVideoActivity();
 
     const auto shutdownElapsedUs = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - shutdownStartedAt).count();
     OH_LOG_INFO(LOG_APP,
-        "[ExtLoader][SHUTDOWN] phase=disconnect-all-return sessions=%{public}zu elapsedUs=%{public}lld",
-        sessions.size(), static_cast<long long>(shutdownElapsedUs));
+        "[ExtLoader][SHUTDOWN] requestId=%{public}llu phase=disconnect-all-return sessions=%{public}zu elapsedUs=%{public}lld",
+        static_cast<unsigned long long>(requestId), sessions.size(),
+        static_cast<long long>(shutdownElapsedUs));
 
-    napi_value undefined;
-    napi_get_undefined(env, &undefined);
-    return undefined;
+    napi_value result;
+    napi_create_int64(env, static_cast<int64_t>(requestId), &result);
+    return result;
+}
+
+napi_value NapiGetDisconnectState(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    int64_t requestId = 0;
+    if (argc > 0) {
+        napi_get_value_int64(env, args[0], &requestId);
+    }
+    napi_value result;
+    napi_create_int32(env, static_cast<int32_t>(
+        g_teardownExecutor.state(static_cast<uint64_t>(requestId))), &result);
+    return result;
 }
 
 /**
@@ -2084,9 +2320,17 @@ napi_value ExtensionLoaderNapi::Init(napi_env env, napi_value exports) {
                          NapiDisconnect, nullptr, &fn);
     napi_set_named_property(env, exports, "disconnect", fn);
 
+    napi_create_function(env, "beginDisconnect", NAPI_AUTO_LENGTH,
+                         NapiDisconnect, nullptr, &fn);
+    napi_set_named_property(env, exports, "beginDisconnect", fn);
+
     napi_create_function(env, "disconnectAll", NAPI_AUTO_LENGTH,
                          NapiDisconnectAll, nullptr, &fn);
     napi_set_named_property(env, exports, "disconnectAll", fn);
+
+    napi_create_function(env, "getDisconnectState", NAPI_AUTO_LENGTH,
+                         NapiGetDisconnectState, nullptr, &fn);
+    napi_set_named_property(env, exports, "getDisconnectState", fn);
 
     napi_create_function(env, "sendKey", NAPI_AUTO_LENGTH,
                          NapiSendKey, nullptr, &fn);

--- a/entry/src/main/cpp/extensions/session_teardown_executor.cpp
+++ b/entry/src/main/cpp/extensions/session_teardown_executor.cpp
@@ -1,0 +1,141 @@
+/**
+ * session_teardown_executor.cpp - serialized background teardown execution
+ */
+
+#include "session_teardown_executor.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+
+namespace SessionTeardown {
+
+namespace {
+
+constexpr std::size_t kRetainedTerminalStates = 256;
+
+bool IsTerminal(State state) {
+    return state == State::Complete || state == State::Failed;
+}
+
+} // namespace
+
+struct Executor::Impl {
+    struct WorkItem {
+        std::uint64_t requestId = 0;
+        Task task;
+    };
+
+    mutable std::mutex mutex;
+    std::mutex shutdownMutex;
+    std::condition_variable workCv;
+    std::condition_variable stateCv;
+    std::deque<WorkItem> queue;
+    std::unordered_map<std::uint64_t, State> states;
+    std::deque<std::uint64_t> terminalOrder;
+    std::atomic<std::uint64_t> nextRequestId {1};
+    bool accepting = true;
+    bool stopping = false;
+    std::thread worker;
+
+    Impl() : worker([this]() { run(); }) {}
+
+    void run() {
+        while (true) {
+            WorkItem item;
+            {
+                std::unique_lock<std::mutex> lock(mutex);
+                workCv.wait(lock, [this]() { return stopping || !queue.empty(); });
+                if (queue.empty()) {
+                    if (stopping) {
+                        return;
+                    }
+                    continue;
+                }
+                item = std::move(queue.front());
+                queue.pop_front();
+                states[item.requestId] = State::Running;
+                stateCv.notify_all();
+            }
+
+            State terminalState = State::Complete;
+            try {
+                item.task();
+            } catch (...) {
+                terminalState = State::Failed;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                states[item.requestId] = terminalState;
+                terminalOrder.push_back(item.requestId);
+                while (terminalOrder.size() > kRetainedTerminalStates) {
+                    const std::uint64_t expired = terminalOrder.front();
+                    terminalOrder.pop_front();
+                    auto it = states.find(expired);
+                    if (it != states.end() && IsTerminal(it->second)) {
+                        states.erase(it);
+                    }
+                }
+            }
+            stateCv.notify_all();
+        }
+    }
+};
+
+Executor::Executor() : impl_(std::make_unique<Impl>()) {}
+
+Executor::~Executor() {
+    shutdown();
+}
+
+std::uint64_t Executor::enqueue(Task task) {
+    if (!task) {
+        return 0;
+    }
+    const std::uint64_t requestId = impl_->nextRequestId.fetch_add(1, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        if (!impl_->accepting) {
+            return 0;
+        }
+        impl_->states[requestId] = State::Queued;
+        impl_->queue.push_back({requestId, std::move(task)});
+    }
+    impl_->workCv.notify_one();
+    return requestId;
+}
+
+State Executor::state(std::uint64_t requestId) const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    const auto it = impl_->states.find(requestId);
+    return it == impl_->states.end() ? State::Unknown : it->second;
+}
+
+bool Executor::waitFor(std::uint64_t requestId, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(impl_->mutex);
+    const bool reachedTerminal = impl_->stateCv.wait_for(lock, timeout, [this, requestId]() {
+        const auto it = impl_->states.find(requestId);
+        return it != impl_->states.end() && IsTerminal(it->second);
+    });
+    return reachedTerminal;
+}
+
+void Executor::shutdown() {
+    std::lock_guard<std::mutex> shutdownLock(impl_->shutdownMutex);
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        impl_->accepting = false;
+        impl_->stopping = true;
+    }
+    impl_->workCv.notify_all();
+    if (impl_->worker.joinable() && impl_->worker.get_id() != std::this_thread::get_id()) {
+        impl_->worker.join();
+    }
+}
+
+} // namespace SessionTeardown

--- a/entry/src/main/cpp/extensions/session_teardown_executor.h
+++ b/entry/src/main/cpp/extensions/session_teardown_executor.h
@@ -1,0 +1,45 @@
+/**
+ * session_teardown_executor.h - serialized background teardown execution
+ */
+
+#ifndef SESSION_TEARDOWN_EXECUTOR_H
+#define SESSION_TEARDOWN_EXECUTOR_H
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+namespace SessionTeardown {
+
+enum class State : std::uint8_t {
+    Unknown = 0,
+    Queued,
+    Running,
+    Complete,
+    Failed,
+};
+
+class Executor {
+public:
+    using Task = std::function<void()>;
+
+    Executor();
+    ~Executor();
+
+    Executor(const Executor&) = delete;
+    Executor& operator=(const Executor&) = delete;
+
+    std::uint64_t enqueue(Task task);
+    State state(std::uint64_t requestId) const;
+    bool waitFor(std::uint64_t requestId, std::chrono::milliseconds timeout);
+    void shutdown();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace SessionTeardown
+
+#endif // SESSION_TEARDOWN_EXECUTOR_H

--- a/entry/src/main/cpp/rdp/freerdp_adapter.cpp
+++ b/entry/src/main/cpp/rdp/freerdp_adapter.cpp
@@ -856,6 +856,7 @@ struct FreeRdpAdapter::Impl {
 
 static std::mutex g_rdpAudioCallbackMutex;
 static AudioDataCallback g_rdpAudioCallback;
+static FreeRdpAdapter* g_rdpAudioCallbackOwner = nullptr;
 static std::once_flag g_rdpAddinProviderOnce;
 
 static void ensureFreeRdpStaticAddinProvider() {
@@ -1825,7 +1826,13 @@ int FreeRdpAdapter::connect(const ConnectionConfig& cfg) {
     impl_->stopRequested = false;
     {
         std::lock_guard<std::mutex> lock(g_rdpAudioCallbackMutex);
-        g_rdpAudioCallback = cfg.rdAudioEnabled ? impl_->audioCallback : nullptr;
+        if (cfg.rdAudioEnabled && impl_->audioCallback) {
+            g_rdpAudioCallbackOwner = this;
+            g_rdpAudioCallback = impl_->audioCallback;
+        } else if (g_rdpAudioCallbackOwner == this) {
+            g_rdpAudioCallbackOwner = nullptr;
+            g_rdpAudioCallback = nullptr;
+        }
     }
     impl_->setState(ConnectionState::CONNECTING, "Connecting...");
 
@@ -2150,7 +2157,10 @@ void FreeRdpAdapter::disconnect() {
     cleanupInstance();
     {
         std::lock_guard<std::mutex> lock(g_rdpAudioCallbackMutex);
-        g_rdpAudioCallback = nullptr;
+        if (g_rdpAudioCallbackOwner == this) {
+            g_rdpAudioCallbackOwner = nullptr;
+            g_rdpAudioCallback = nullptr;
+        }
     }
 
     if (impl_->state != ConnectionState::DISCONNECTED &&
@@ -2389,7 +2399,13 @@ void FreeRdpAdapter::setAudioCallback(AudioDataCallback cb) {
     impl_->audioCallback = std::move(cb);
     if (impl_->config.rdAudioEnabled) {
         std::lock_guard<std::mutex> lock(g_rdpAudioCallbackMutex);
-        g_rdpAudioCallback = impl_->audioCallback;
+        if (impl_->audioCallback) {
+            g_rdpAudioCallbackOwner = this;
+            g_rdpAudioCallback = impl_->audioCallback;
+        } else if (g_rdpAudioCallbackOwner == this) {
+            g_rdpAudioCallbackOwner = nullptr;
+            g_rdpAudioCallback = nullptr;
+        }
     }
 }
 void FreeRdpAdapter::setConnectionStateCallback(ConnectionStateCallback cb) { impl_->stateCallback = std::move(cb); }

--- a/entry/src/main/cpp/render/gl_renderer.cpp
+++ b/entry/src/main/cpp/render/gl_renderer.cpp
@@ -1054,17 +1054,8 @@ napi_value NapiDestroyRenderer(napi_env env, napi_callback_info info) {
 
     int64_t handleVal;
     napi_get_value_int64(env, args[0], &handleVal);
-    auto* ctx = reinterpret_cast<RendererContext*>(handleVal);
-
-    if (ctx) {
-        if (g_activeRendererHandle.load() == handleVal) {
-            g_activeRendererHandle.store(0);
-        }
-        if (ctx->renderer) {
-            ctx->renderer->Destroy();
-        }
-        delete ctx;
-    }
+    RendererNapi::DeactivateRenderer(handleVal);
+    RendererNapi::DestroyRendererHandle(handleVal);
 
     napi_value undefined;
     napi_get_undefined(env, &undefined);
@@ -1254,6 +1245,28 @@ void RendererNapi::SetActiveRenderer(int64_t handle) {
     g_activeRendererHandle.store(handle);
     OH_LOG_INFO(LOG_APP, "[GL] active renderer set handle=%{public}lld",
                 static_cast<long long>(handle));
+}
+
+void RendererNapi::DeactivateRenderer(int64_t handle) {
+    if (handle <= 0) {
+        return;
+    }
+    int64_t expected = handle;
+    g_activeRendererHandle.compare_exchange_strong(expected, 0);
+}
+
+void RendererNapi::DestroyRendererHandle(int64_t handle) {
+    if (handle <= 0) {
+        return;
+    }
+    auto* ctx = reinterpret_cast<RendererContext*>(handle);
+    if (!ctx) {
+        return;
+    }
+    if (ctx->renderer) {
+        ctx->renderer->Destroy();
+    }
+    delete ctx;
 }
 
 int RendererNapi::RenderRawBgraActive(

--- a/entry/src/main/cpp/render/gl_renderer.h
+++ b/entry/src/main/cpp/render/gl_renderer.h
@@ -154,6 +154,8 @@ namespace RendererNapi {
     int RenderRawBgraRectActive(const uint8_t* data, size_t size, int width, int height, int stride,
                                 int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight);
     void SetActiveRenderer(int64_t handle);
+    void DeactivateRenderer(int64_t handle);
+    void DestroyRendererHandle(int64_t handle);
 }
 
 #endif // GL_RENDERER_H

--- a/entry/src/main/cpp/render/hw_decoder.cpp
+++ b/entry/src/main/cpp/render/hw_decoder.cpp
@@ -1074,21 +1074,8 @@ napi_value NapiDestroyDecoder(napi_env env, napi_callback_info info) {
 
     int64_t handleVal;
     napi_get_value_int64(env, args[0], &handleVal);
-    auto* ctx = reinterpret_cast<DecoderContext*>(handleVal);
-
-    if (ctx) {
-        if (g_activeDecoderHandle.load() == handleVal) {
-            g_activeDecoderHandle.store(0);
-        }
-        StopSoftwareWorker(ctx);
-        if (ctx->decoder) {
-            ctx->decoder->Destroy();
-        }
-        if (ctx->softwareDecoder) {
-            ctx->softwareDecoder->Destroy();
-        }
-        delete ctx;
-    }
+    DecoderNapi::DeactivateDecoder(handleVal);
+    DecoderNapi::DestroyDecoderHandle(handleVal);
 
     napi_value undefined;
     napi_get_undefined(env, &undefined);
@@ -1252,6 +1239,32 @@ int DecoderNapi::DecodeActiveNative(const VideoFrame& frame) {
         return -1;
     }
     return DecodeNative(handle, frame);
+}
+
+void DecoderNapi::DeactivateDecoder(int64_t handle) {
+    if (handle <= 0) {
+        return;
+    }
+    int64_t expected = handle;
+    g_activeDecoderHandle.compare_exchange_strong(expected, 0);
+}
+
+void DecoderNapi::DestroyDecoderHandle(int64_t handle) {
+    if (handle <= 0) {
+        return;
+    }
+    auto* ctx = reinterpret_cast<DecoderContext*>(handle);
+    if (!ctx) {
+        return;
+    }
+    StopSoftwareWorker(ctx);
+    if (ctx->decoder) {
+        ctx->decoder->Destroy();
+    }
+    if (ctx->softwareDecoder) {
+        ctx->softwareDecoder->Destroy();
+    }
+    delete ctx;
 }
 
 int DecoderNapi::ActiveVideoPressureLevel() {

--- a/entry/src/main/cpp/render/hw_decoder.h
+++ b/entry/src/main/cpp/render/hw_decoder.h
@@ -222,6 +222,8 @@ namespace DecoderNapi {
     bool BindVideoPipeline(int64_t decoderHandle, int64_t rendererHandle);
     bool DetachVideoPipeline(int64_t decoderHandle);
     bool RequestDecoderRecovery(int64_t decoderHandle);
+    void DeactivateDecoder(int64_t decoderHandle);
+    void DestroyDecoderHandle(int64_t decoderHandle);
 }
 
 #endif // HW_DECODER_H

--- a/entry/src/main/cpp/test/session_teardown_executor_test.cpp
+++ b/entry/src/main/cpp/test/session_teardown_executor_test.cpp
@@ -1,0 +1,62 @@
+/**
+ * session_teardown_executor_test.cpp - asynchronous teardown execution contracts
+ */
+
+#include "test_runner.h"
+#include "extensions/session_teardown_executor.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
+
+using SessionTeardown::Executor;
+using SessionTeardown::State;
+
+RDP_TEST_CASE(session_teardown_enqueue_returns_without_waiting_for_task) {
+    Executor executor;
+    std::mutex gateMutex;
+    std::condition_variable gateCv;
+    bool release = false;
+
+    const auto started = std::chrono::steady_clock::now();
+    const uint64_t requestId = executor.enqueue([&]() {
+        std::unique_lock<std::mutex> lock(gateMutex);
+        gateCv.wait(lock, [&]() { return release; });
+    });
+    const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started).count();
+
+    RDP_ASSERT(requestId > 0);
+    RDP_ASSERT(elapsedMs < 50);
+    const State initialState = executor.state(requestId);
+    RDP_ASSERT(initialState == State::Queued || initialState == State::Running);
+
+    {
+        std::lock_guard<std::mutex> lock(gateMutex);
+        release = true;
+    }
+    gateCv.notify_all();
+    RDP_ASSERT(executor.waitFor(requestId, std::chrono::milliseconds(1000)));
+    RDP_ASSERT_EQ(executor.state(requestId), State::Complete);
+}
+
+RDP_TEST_CASE(session_teardown_executor_drains_on_shutdown) {
+    std::atomic<bool> completed {false};
+    {
+        Executor executor;
+        RDP_ASSERT(executor.enqueue([&]() { completed.store(true); }) > 0);
+    }
+    RDP_ASSERT(completed.load());
+}
+
+RDP_TEST_CASE(session_teardown_executor_reports_failed_task) {
+    Executor executor;
+    const uint64_t requestId = executor.enqueue([]() {
+        throw std::runtime_error("expected teardown test failure");
+    });
+
+    RDP_ASSERT(executor.waitFor(requestId, std::chrono::milliseconds(1000)));
+    RDP_ASSERT_EQ(executor.state(requestId), State::Failed);
+}

--- a/entry/src/main/ets/pages/RemoteDesktop.ets
+++ b/entry/src/main/ets/pages/RemoteDesktop.ets
@@ -2306,6 +2306,9 @@ struct RemoteDesktop {
   private async doConnect(host: RemoteHost): Promise<void> {
     const attemptId: number = ++this.connectAttemptId;
     try {
+      if (!(await this.loader.waitForPendingTeardown())) {
+        throw new Error('上一会话资源清理未完成 [E-TEARDOWN-PENDING]');
+      }
       const desktop: DesktopSize = this.desktopSize(host);
       this.updateRemoteSize(desktop);
       const credentials: RdpCredentialParts = this.rdpCredentialParts(host);
@@ -2646,32 +2649,26 @@ struct RemoteDesktop {
       this.connectAttemptId++;
       this.inputForwardReady = false;
       const shouldRestoreOrientation: boolean = this.orientationApplied;
-      if (this.sessionId > 0) {
-        this.disableRdpBackgroundVideoPrewarm('disconnect-cleanup');
+      if (this.sessionId > 0 || this.rendererHandle > 0 || this.decoderHandle > 0) {
+        if (this.sessionId > 0) {
+          this.disableRdpBackgroundVideoPrewarm('disconnect-cleanup');
+        }
         this.flushMouseMove();
+        if (this.rendererHandle > 0) {
+          this.markXComponentSurfaceDetached('disconnectAndCleanup');
+        }
         const nativeDisconnectStartedAtMs: number = Date.now();
         hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=native-disconnect-begin sessionId=' +
           this.sessionId.toString());
-        this.loader.disconnect();
-        hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=native-disconnect-return elapsedMs=' +
+        const disconnectRequestId: number = this.loader.disconnect();
+        hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=native-disconnect-return requestId=' +
+          disconnectRequestId.toString() + ' elapsedMs=' +
           (Date.now() - nativeDisconnectStartedAtMs).toString());
         this.sessionId = -1;
-        this.nativeHandles.markProtocolDisconnected();
-      }
-      if (this.decoderHandle > 0) {
-        this.loader.destroyDecoder();
-        this.decoderHandle = -1;
-      }
-      if (this.rendererHandle > 0) {
-        const rendererDestroyStartedAtMs: number = Date.now();
-        hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=renderer-destroy-begin');
-        this.markXComponentSurfaceDetached('disconnectAndCleanup');
-        this.loader.destroyRenderer();
         this.rendererHandle = -1;
-        hilog.info(RD_DOMAIN, RD_TAG, '[RDP-SHUTDOWN] phase=renderer-destroy-return elapsedMs=' +
-          (Date.now() - rendererDestroyStartedAtMs).toString());
+        this.decoderHandle = -1;
+        this.nativeHandles.markAsyncTeardownTransferred();
       }
-      this.loader.destroyAudioPlayer();
       this.clearFileTransferAutoHide();
       this.fileTransferBusy = false;
       this.fileTransferProgress = -1;

--- a/entry/src/main/ets/pages/SshTerminal.ets
+++ b/entry/src/main/ets/pages/SshTerminal.ets
@@ -683,6 +683,9 @@ struct SshTerminal {
 
   private async connect(host: RemoteHost): Promise<void> {
     try {
+      if (!(await this.loader.waitForPendingTeardown())) {
+        throw new Error('上一会话资源清理未完成 [E-TEARDOWN-PENDING]');
+      }
       this.sshHost = host.host;
       this.sshPort = host.port;
       // 密钥解析: sshKeyId 优先 (引用 KeyVault), 回退 sshKeyData (旧副本)

--- a/entry/src/main/ets/services/ExtensionLoader.ets
+++ b/entry/src/main/ets/services/ExtensionLoader.ets
@@ -36,6 +36,7 @@ export class ExtensionLoader {
   private rendererHandle: number = -1;
   private decoderHandle: number = -1;
   private audioPlayerHandle: number = -1;
+  private teardownRequestId: number = 0;
 
   static getInstance(): ExtensionLoader {
     if (!ExtensionLoader.instance) { ExtensionLoader.instance = new ExtensionLoader(); }
@@ -54,20 +55,32 @@ export class ExtensionLoader {
     }
   }
 
-  disconnect(): void {
+  disconnect(): number {
+    let requestId: number = 0;
     try {
-      if (this.currentSessionId > 0) {
-        rdpnapi.disconnect(this.currentSessionId);
+      if (this.currentSessionId > 0 || this.rendererHandle > 0 ||
+        this.decoderHandle > 0 || this.audioPlayerHandle > 0) {
+        requestId = rdpnapi.beginDisconnect(this.currentSessionId, this.rendererHandle,
+          this.decoderHandle, this.audioPlayerHandle) as number;
       }
     } catch (err) {
       hilog.error(DOMAIN, TAG, '[ExtensionLoader] disconnect: ' + JSON.stringify(err));
     }
     this.currentSessionId = -1;
+    this.rendererHandle = -1;
+    this.decoderHandle = -1;
+    this.audioPlayerHandle = -1;
+    if (requestId > 0) {
+      this.teardownRequestId = requestId;
+    }
+    return requestId;
   }
 
-  disconnectAll(): void {
+  disconnectAll(): number {
+    let requestId: number = 0;
     try {
-      rdpnapi.disconnectAll();
+      requestId = rdpnapi.disconnectAll(
+        this.rendererHandle, this.decoderHandle, this.audioPlayerHandle) as number;
     } catch (err) {
       hilog.error(DOMAIN, TAG, '[ExtensionLoader] disconnectAll: ' + JSON.stringify(err));
     }
@@ -75,6 +88,39 @@ export class ExtensionLoader {
     this.rendererHandle = -1;
     this.decoderHandle = -1;
     this.audioPlayerHandle = -1;
+    if (requestId > 0) {
+      this.teardownRequestId = requestId;
+    }
+    return requestId;
+  }
+
+  getDisconnectState(requestId: number): number {
+    try {
+      return rdpnapi.getDisconnectState(requestId) as number;
+    } catch (_err) {
+      return 0;
+    }
+  }
+
+  async waitForPendingTeardown(timeoutMs: number = 10000): Promise<boolean> {
+    if (this.teardownRequestId <= 0) {
+      return true;
+    }
+    const startedAtMs: number = Date.now();
+    while (Date.now() - startedAtMs < timeoutMs) {
+      const state: number = this.getDisconnectState(this.teardownRequestId);
+      if (state === 3 || state === 0) {
+        this.teardownRequestId = 0;
+        return true;
+      }
+      if (state === 4) {
+        return false;
+      }
+      await new Promise<void>((resolve: () => void): void => {
+        setTimeout(resolve, 20);
+      });
+    }
+    return false;
   }
 
   isConnected(): boolean { return this.currentSessionId > 0; }
@@ -827,10 +873,11 @@ export class ExtensionLoader {
    */
   disconnectForExit(reason: string): ExtensionResult<void> {
     try {
-      if (this.currentSessionId > 0) {
-        rdpnapi.disconnect(this.currentSessionId);
+      const sessionId: number = this.currentSessionId;
+      const requestId: number = this.disconnect();
+      if (requestId > 0) {
         hilog.info(DOMAIN, TAG, '[ExtensionLoader] disconnectForExit: reason=' + reason +
-          ' sessionId=' + this.currentSessionId.toString());
+          ' sessionId=' + sessionId.toString() + ' requestId=' + requestId.toString());
       }
     } catch (err) {
       hilog.error(DOMAIN, TAG, '[ExtensionLoader] disconnectForExit: ' + JSON.stringify(err));

--- a/entry/src/main/ets/services/NativeSessionHandles.ets
+++ b/entry/src/main/ets/services/NativeSessionHandles.ets
@@ -67,7 +67,7 @@ export class ProductionNativeHandleAdapter implements NativeHandleAdapter {
 // ====== ExtensionLoader 所需的最小接口 (避免循环导入) ======
 
 export interface ExtensionLoaderLike {
-  disconnect(): void;
+  disconnect(): number;
   destroyRenderer(): void;
   destroyAudioPlayer(): void;
   initRenderer(surfaceId: string, width: number, height: number): number;
@@ -140,30 +140,30 @@ export class NativeSessionHandles {
   }
 
   /**
-   * 完全断连+释放: 先 mark surface destroyed → 渲染清理 → 音频清理 → 协议断连。
-   * 严格顺序: surface → renderer → audio → protocol。
+   * 完全断连+释放: UI 只标记 surface 并提交异步 native teardown。
+   * renderer/audio 的真实销毁由 native executor 在协议 worker 停止后完成。
    */
   disconnectAndRelease(reason: string): void {
-    // 1. 标记 surface destroyed (如果渲染仍然 attached)
     if (this.renderAttached) {
       this.adapter.markXComponentSurfaceDestroyed();
-      this.adapter.destroyRendererOnly();
       this.renderAttached = false;
       this.rendererHandle = -1;
     }
 
-    // 2. 销毁音频
-    if (this.audioActive) {
-      this.adapter.destroyAudio();
-      this.audioActive = false;
-    }
-
-    // 3. 断开协议
     if (this.protocolConnected) {
       this.adapter.disconnectProtocol();
       this.protocolConnected = false;
     }
 
+    this.audioActive = false;
+    this.sessionId = -1;
+  }
+
+  markAsyncTeardownTransferred(): void {
+    this.protocolConnected = false;
+    this.renderAttached = false;
+    this.audioActive = false;
+    this.rendererHandle = -1;
     this.sessionId = -1;
   }
 

--- a/entry/src/main/ets/types/rdpnapi.d.ts
+++ b/entry/src/main/ets/types/rdpnapi.d.ts
@@ -4,8 +4,13 @@ declare module 'librdpnapi.so' {
   export function listProtocols(): ProtocolInfo[];
 
   export function connect(config: SessionConfig): number;
-  export function disconnect(sessionId: number): void;
-  export function disconnectAll(): void;
+  export function disconnect(sessionId: number, rendererHandle?: number,
+    decoderHandle?: number, audioHandle?: number): number;
+  export function beginDisconnect(sessionId: number, rendererHandle: number,
+    decoderHandle: number, audioHandle: number): number;
+  export function disconnectAll(rendererHandle?: number, decoderHandle?: number,
+    audioHandle?: number): number;
+  export function getDisconnectState(requestId: number): number;
 
   export function sendKey(sessionId: number, scancode: number, pressed: boolean): void;
   export function sendMouse(sessionId: number, x: number, y: number, button: number, pressed: boolean): void;

--- a/entry/src/ohosTest/ets/test/NativeSessionHandles.test.ets
+++ b/entry/src/ohosTest/ets/test/NativeSessionHandles.test.ets
@@ -118,7 +118,7 @@ export default function nativeSessionHandlesTest(): void {
       expect(spy.calls.length).assertEqual(0);
     });
 
-    // ----- 完全断连 (核心测试 — 验证调用顺序) -----
+    // ----- 完全断连 (UI 只提交异步 teardown) -----
 
     it('disconnect_and_release_should_follow_safe_order', 0, (): void => {
       const spy = new SpyAdapter();
@@ -130,23 +130,16 @@ export default function nativeSessionHandlesTest(): void {
 
       handles.disconnectAndRelease('test');
 
-      // 严格顺序: surface → renderer → audio → protocol
-      // 至少有 4 个调用
-      expect(spy.calls.length >= 4).assertEqual(true);
+      // UI 线程只标记 surface 并提交协议 teardown；资源释放由 native executor 完成。
+      expect(spy.calls.length).assertEqual(2);
       const surfaceIdx: number = spy.calls.indexOf('markXComponentSurfaceDestroyed');
-      const renderIdx: number = spy.calls.indexOf('destroyRendererOnly');
-      const audioIdx: number = spy.calls.indexOf('destroyAudio');
       const protoIdx: number = spy.calls.indexOf('disconnectProtocol');
 
       expect(surfaceIdx >= 0).assertEqual(true);
-      expect(renderIdx >= 0).assertEqual(true);
-      expect(audioIdx >= 0).assertEqual(true);
       expect(protoIdx >= 0).assertEqual(true);
-
-      // surface 必须在 renderer 之前
-      expect(surfaceIdx < renderIdx).assertEqual(true);
-      // audio 必须在 protocol 之前
-      expect(audioIdx < protoIdx).assertEqual(true);
+      expect(surfaceIdx < protoIdx).assertEqual(true);
+      expect(spy.calls.indexOf('destroyRendererOnly') < 0).assertEqual(true);
+      expect(spy.calls.indexOf('destroyAudio') < 0).assertEqual(true);
     });
 
     it('disconnect_and_release_should_clear_all_state', 0, (): void => {


### PR DESCRIPTION
## Summary
- add a serialized background session teardown executor with queryable request state
- transfer adapter, renderer, decoder and audio ownership out of ArkTS before returning
- make disconnect and disconnectAll idempotent and prevent callbacks from touching stale NAPI/UI state
- gate reconnect asynchronously until the previous native resources are released
- keep RDP audio callback ownership session-scoped

## Verification
- native tests: 81 passed, 0 failed
- default@OhosTestCompileArkTS: passed
- assembleHap: passed for arm64-v8a and x86_64
- open-source compliance Light gate: passed
- emulator install/launch: passed
- real RDP login-failure cleanup: NAPI returned in 121 us; background protocol/resource teardown completed in 388394 us; ArkTS exit returned in 1 ms; host list responsive

## Pressure testing
- intentionally deferred per requested sequence until the remaining presentation pipeline tasks are implemented