### PR TITLE
perf(rdp): accumulate owned dirty frames

### DIFF
--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -33,6 +33,7 @@ set(PROTOCOL_SOURCES
     rdp/rdp_audio_policy.cpp
     rdp/rdp_auth_identity_policy.cpp
     rdp/rdp_background_frame_cache.cpp
+    rdp/rdp_damage_accumulator.cpp
     rdp/rdp_frame_pump.cpp
     rustdesk/rustdesk_bridge.cpp
 )
@@ -138,6 +139,7 @@ if(RDP_BUILD_TESTS)
         test/rdp_shutdown_state_test.cpp
         test/session_teardown_executor_test.cpp
         test/rdp_background_frame_cache_test.cpp
+        test/rdp_damage_accumulator_test.cpp
         test/rdp_certificate_policy_test.cpp
         test/rdp_auth_identity_policy_test.cpp
         test/rdp_performance_policy_test.cpp
@@ -152,6 +154,7 @@ if(RDP_BUILD_TESTS)
         rdp/rdp_audio_policy.cpp
         rdp/rdp_auth_identity_policy.cpp
         rdp/rdp_background_frame_cache.cpp
+        rdp/rdp_damage_accumulator.cpp
         audio/audio_queue_policy.cpp
         audio/audio_activity_state.cpp
         video/video_activity_state.cpp

--- a/entry/src/main/cpp/rdp/freerdp_adapter.cpp
+++ b/entry/src/main/cpp/rdp/freerdp_adapter.cpp
@@ -539,6 +539,9 @@ struct FreeRdpAdapter::Impl {
     std::atomic<uint64_t>   sessionGeneration {0};
     std::atomic<int64_t>    shutdownStartedUs {0};
     RdpFramePump            framePump;
+    std::shared_ptr<RdpDamageAccumulator> damageAccumulator {
+        std::make_shared<RdpDamageAccumulator>()
+    };
     std::atomic<bool>       backgroundVideoPrewarmEnabled {false};
     std::atomic<uint32_t>   backgroundVideoPrewarmIntervalMs {1000};
     RdpBackgroundFrameCache backgroundFrameCache;
@@ -728,6 +731,7 @@ struct FreeRdpAdapter::Impl {
         traceShutdown("frame-pump-stop", "begin");
         framePump.stop();
         traceShutdown("frame-pump-stop", "complete");
+        damageAccumulator->clear();
     }
 
     void setState(ConnectionState s, const std::string& msg = "") {
@@ -1245,6 +1249,7 @@ BOOL FreeRdpAdapter::cbPostConnect(freerdp* instance) {
     self->impl_->lastFrameWidth = 0;
     self->impl_->lastFrameHeight = 0;
     self->impl_->forceNextFullFrame = true;
+    self->impl_->damageAccumulator->clear();
     RendererNapi::ReenableActivePresentation();
     self->impl_->presentationEnabled.store(true, std::memory_order_release);
     self->impl_->startSessionWorkers(self);
@@ -1302,24 +1307,10 @@ BOOL FreeRdpAdapter::cbEndPaint(rdpContext* context) {
         const int invalidY = hasInvalid ? hwnd->invalid->y : 0;
         const int invalidW = hasInvalid ? hwnd->invalid->w : 0;
         const int invalidH = hasInvalid ? hwnd->invalid->h : 0;
-        const RdpRenderPolicy::DirtyRect dirtyRect =
-            RdpRenderPolicy::NormalizeDirtyRect(w, h, invalidX, invalidY, invalidW, invalidH);
-        const bool frameSizeChanged =
-            self->impl_->lastFrameWidth != 0 &&
-            (self->impl_->lastFrameWidth != w || self->impl_->lastFrameHeight != h);
-        const bool requiresFullFrameResync = self->impl_->forceNextFullFrame ||
-            self->impl_->framePump.consumeFullResyncRequired();
-        // Keep the June 26 stable presentation path: throttled frames render full primary buffers.
-        constexpr bool kEnableDirtyRectUploads = false;
-        const bool useDirtyRect = !frameSizeChanged &&
-            RdpRenderPolicy::ShouldUseDirtyRect(self->impl_->renderedPaintCount,
-                                                dirtyRect,
-                                                static_cast<long long>(size),
-                                                requiresFullFrameResync,
-                                                kEnableDirtyRectUploads);
-        const size_t renderBytes = useDirtyRect ?
-            static_cast<size_t>(dirtyRect.width) * static_cast<size_t>(dirtyRect.height) * 4U :
-            size;
+        const RdpDamageRect dirtyRect = RdpDamageAccumulator::ClipRect(
+            w, h, invalidX, invalidY, invalidW, invalidH);
+        const size_t renderBytes = dirtyRect.valid ?
+            static_cast<size_t>(dirtyRect.width) * static_cast<size_t>(dirtyRect.height) * 4U : 0;
         const uint64_t nowMs = static_cast<uint64_t>(steadyNowUs() / 1000);
         if (ShouldCaptureRdpBackgroundFrame(
                 self->impl_->backgroundVideoPrewarmEnabled.load(),
@@ -1363,76 +1354,82 @@ BOOL FreeRdpAdapter::cbEndPaint(rdpContext* context) {
         const bool shouldRender = self->impl_->renderedPaintCount == 0 ||
             nowUs - self->impl_->lastRenderUs >= self->impl_->minRenderIntervalUs;
 
+        const RdpPresentationTarget target = RendererNapi::GetActivePresentationTarget();
+        const bool stagingAllowed =
+            self->impl_->presentationEnabled.load(std::memory_order_acquire) &&
+            target.generation != 0;
+        const bool presentationAllowed = stagingAllowed && target.ready();
+        const bool frameSizeChanged = self->impl_->lastFrameWidth != 0 &&
+            (self->impl_->lastFrameWidth != w || self->impl_->lastFrameHeight != h);
+        const bool forceFullDamage = self->impl_->forceNextFullFrame || frameSizeChanged ||
+            self->impl_->framePump.consumeFullResyncRequired();
+        RdpDamageUpdateResult damageUpdate;
+        if (stagingAllowed) {
+            const int64_t copyBeginUs = steadyNowUs();
+            damageUpdate = self->impl_->damageAccumulator->update(
+                data, size, w, h, stride, invalidX, invalidY, invalidW, invalidH,
+                target.generation, forceFullDamage);
+            self->impl_->framePump.recordCopy(
+                damageUpdate.copiedBytes, steadyNowUs() - copyBeginUs, steadyNowUs());
+        }
+
         int ret = 0;
         int64_t renderCostUs = 0;
-        if (shouldRender) {
-            const RdpPresentationTarget target =
-                RendererNapi::GetActivePresentationTarget();
-            const bool presentationAllowed =
-                self->impl_->presentationEnabled.load(std::memory_order_acquire) && target.ready();
-            bool queued = false;
-            RdpPresentMetrics present;
-            present.generation = target.generation;
-            if (!self->impl_->presentationEnabled.load(std::memory_order_acquire)) {
-                present.result = RdpPresentResult::RendererNotReady;
-            } else if (!target.ready()) {
-                present.result = target.rejection;
-            } else if (self->impl_->renderedPaintCount >= 3) {
+        bool queued = false;
+        bool dirtyPresentation = damageUpdate.accepted && !damageUpdate.fullResync;
+        RdpPresentMetrics present;
+        present.generation = target.generation;
+        if (!presentationAllowed) {
+            present.result = stagingAllowed ?
+                target.rejection : RdpPresentResult::RendererNotReady;
+            self->impl_->forceNextFullFrame = !damageUpdate.accepted;
+            self->impl_->framePump.recordDirectPresent(present, steadyNowUs());
+        } else if (!damageUpdate.accepted) {
+            present.result = RdpPresentResult::InvalidFrame;
+            self->impl_->forceNextFullFrame = true;
+            self->impl_->framePump.recordDirectPresent(present, steadyNowUs());
+        } else if (!shouldRender) {
+            self->impl_->skippedPaintCount++;
+            self->impl_->forceNextFullFrame = false;
+        } else {
+            if (self->impl_->renderedPaintCount >= 3) {
                 RdpFrameSubmission submission;
-                const int64_t copyBeginUs = steadyNowUs();
-                try {
-                    submission.pixels.assign(data, data + size);
-                } catch (const std::exception& e) {
-                    OH_LOG_WARN(LOG_APP, "[RDP-PRESENT] frame copy failed: %{public}s", e.what());
-                } catch (...) {
-                    OH_LOG_WARN(LOG_APP, "[RDP-PRESENT] frame copy failed: unknown");
-                }
-                if (!submission.pixels.empty()) {
-                    submission.width = w;
-                    submission.height = h;
-                    submission.stride = stride;
-                    submission.dirtyX = dirtyRect.x;
-                    submission.dirtyY = dirtyRect.y;
-                    submission.dirtyWidth = dirtyRect.width;
-                    submission.dirtyHeight = dirtyRect.height;
-                    submission.dirtyValid = false;
-                    submission.rendererGeneration = target.generation;
-                    submission.copiedBytes = size;
-                    submission.copyUs = steadyNowUs() - copyBeginUs;
-                    submission.callbackUs = steadyNowUs() - callbackBeginUs;
-                    submission.enqueuedAtUs = steadyNowUs();
-                    queued = self->impl_->framePump.submitLatest(std::move(submission));
-                }
+                submission.damageSource = self->impl_->damageAccumulator;
+                submission.width = w;
+                submission.height = h;
+                submission.stride = w * 4;
+                submission.rendererGeneration = target.generation;
+                submission.callbackUs = steadyNowUs() - callbackBeginUs;
+                submission.enqueuedAtUs = steadyNowUs();
+                queued = self->impl_->framePump.submitLatest(std::move(submission));
             }
-            if (presentationAllowed &&
-                RdpRenderPolicy::ShouldRenderDirect(self->impl_->renderedPaintCount, queued)) {
-                std::lock_guard<std::mutex> renderLock(self->impl_->renderMutex);
-                if (useDirtyRect) {
-                    const uint8_t* dirtyData = data +
-                        static_cast<size_t>(dirtyRect.y) * static_cast<size_t>(stride) +
-                        static_cast<size_t>(dirtyRect.x) * 4U;
-                    present = RendererNapi::PresentRawBgraRectActive(
-                        dirtyData, renderBytes, w, h, stride,
-                        dirtyRect.x, dirtyRect.y, dirtyRect.width, dirtyRect.height,
-                        target.generation);
+            if (RdpRenderPolicy::ShouldRenderDirect(self->impl_->renderedPaintCount, queued)) {
+                const int64_t snapshotBeginUs = steadyNowUs();
+                RdpDamageSnapshot snapshot = self->impl_->damageAccumulator->takeSnapshot();
+                self->impl_->framePump.recordCopy(
+                    snapshot.snapshotCopiedBytes, steadyNowUs() - snapshotBeginUs, steadyNowUs());
+                if (snapshot.valid) {
+                    dirtyPresentation = !snapshot.fullFrame;
+                    std::lock_guard<std::mutex> renderLock(self->impl_->renderMutex);
+                    present = snapshot.fullFrame ?
+                        RendererNapi::PresentRawBgraActive(
+                            snapshot.pixels.data(), snapshot.pixels.size(), snapshot.width,
+                            snapshot.height, snapshot.stride, snapshot.rendererGeneration) :
+                        RendererNapi::PresentRawBgraRectActive(
+                            snapshot.pixels.data(), snapshot.pixels.size(), snapshot.width,
+                            snapshot.height, snapshot.stride, snapshot.damage.x, snapshot.damage.y,
+                            snapshot.damage.width, snapshot.damage.height,
+                            snapshot.rendererGeneration);
                 } else {
-                    present = RendererNapi::PresentRawBgraActive(
-                        data, size, w, h, stride, target.generation);
+                    present.result = RdpPresentResult::InvalidFrame;
                 }
                 self->impl_->framePump.recordDirectPresent(present, steadyNowUs());
-            } else if (queued) {
-                present.result = RdpPresentResult::Presented;
             } else {
-                self->impl_->framePump.recordDirectPresent(present, steadyNowUs());
+                present.result = RdpPresentResult::Presented;
             }
+
             ret = static_cast<int>(present.result);
-            self->impl_->lastRenderResult = ret;
             renderCostUs = queued ? self->impl_->framePump.lastWorkerCostUs() : present.workerUs();
-            self->impl_->lastRenderCostUs = renderCostUs;
-            self->impl_->lastRenderBytes = static_cast<uint64_t>(renderBytes);
-            if (renderCostUs > 0) {
-                g_rdpVideoPerf.recordRenderCostUs(0, 0, 0, renderCostUs);
-            }
             if (queued || present.presented()) {
                 self->impl_->lastRenderUs = steadyNowUs();
                 self->impl_->lastFrameWidth = w;
@@ -1442,20 +1439,24 @@ BOOL FreeRdpAdapter::cbEndPaint(rdpContext* context) {
             } else {
                 self->impl_->forceNextFullFrame = true;
             }
-            if (renderCostUs > 50000 && (queued || present.presented())) {
-                self->impl_->slowRenderCount++;
-                self->impl_->minRenderIntervalUs = kHeavyRenderIntervalUs;
-            } else if (renderCostUs > 25000 && (queued || present.presented())) {
-                self->impl_->slowRenderCount++;
-                self->impl_->minRenderIntervalUs = kModerateRenderIntervalUs;
-            } else if (renderCostUs > 0 && renderCostUs < 12000 &&
-                       self->impl_->minRenderIntervalUs > kBaseRenderIntervalUs) {
-                self->impl_->slowRenderCount = 0;
-                self->impl_->minRenderIntervalUs = kBaseRenderIntervalUs;
-            }
-        } else {
-            self->impl_->skippedPaintCount++;
-            self->impl_->forceNextFullFrame = true;
+        }
+
+        self->impl_->lastRenderResult = ret;
+        self->impl_->lastRenderCostUs = renderCostUs;
+        self->impl_->lastRenderBytes = damageUpdate.copiedBytes;
+        if (renderCostUs > 0) {
+            g_rdpVideoPerf.recordRenderCostUs(0, 0, 0, renderCostUs);
+        }
+        if (renderCostUs > 50000 && (queued || present.presented())) {
+            self->impl_->slowRenderCount++;
+            self->impl_->minRenderIntervalUs = kHeavyRenderIntervalUs;
+        } else if (renderCostUs > 25000 && (queued || present.presented())) {
+            self->impl_->slowRenderCount++;
+            self->impl_->minRenderIntervalUs = kModerateRenderIntervalUs;
+        } else if (renderCostUs > 0 && renderCostUs < 12000 &&
+                   self->impl_->minRenderIntervalUs > kBaseRenderIntervalUs) {
+            self->impl_->slowRenderCount = 0;
+            self->impl_->minRenderIntervalUs = kBaseRenderIntervalUs;
         }
 
         clearInvalid();
@@ -1483,7 +1484,7 @@ BOOL FreeRdpAdapter::cbEndPaint(rdpContext* context) {
                 static_cast<long long>(renderCostUs),
                 static_cast<long long>(self->impl_->minRenderIntervalUs),
                 self->impl_->slowRenderCount,
-                useDirtyRect ? "dirty" : "full",
+                dirtyPresentation ? "dirty" : "full",
                 static_cast<unsigned long long>(renderBytes),
                 static_cast<unsigned long long>(perf.ingressFrames),
                 static_cast<unsigned long long>(perf.renderFrames),
@@ -2155,32 +2156,13 @@ void FreeRdpAdapter::requestFrameRefresh() {
         return;
     }
 
-    RdpFrameSubmission submission;
-    const int64_t copyBeginUs = steadyNowUs();
-    {
-        std::lock_guard<std::mutex> instanceLock(impl_->instanceMutex);
-        if (!instance_ || !instance_->context || !instance_->context->gdi ||
-            !instance_->context->gdi->primary_buffer) {
-            OH_LOG_WARN(LOG_APP, "[RDP] requestFrameRefresh skipped: GDI primary buffer not ready");
-            return;
-        }
-        auto* gdi = instance_->context->gdi;
-        submission.width = gdi->width;
-        submission.height = gdi->height;
-        submission.stride = gdi->stride;
-        const size_t size = static_cast<size_t>(submission.stride) *
-            static_cast<size_t>(submission.height);
-        try {
-            submission.pixels.assign(gdi->primary_buffer, gdi->primary_buffer + size);
-        } catch (...) {
-            OH_LOG_WARN(LOG_APP, "[RDP] requestFrameRefresh skipped: frame copy failed");
-            return;
-        }
+    if (!impl_->damageAccumulator->requestFullSnapshot(target.generation)) {
+        OH_LOG_WARN(LOG_APP, "[RDP] requestFrameRefresh skipped: owned frame not ready");
+        return;
     }
-    submission.rendererGeneration = target.generation;
-    submission.copiedBytes = submission.pixels.size();
-    submission.copyUs = steadyNowUs() - copyBeginUs;
-    submission.callbackUs = submission.copyUs;
+
+    RdpFrameSubmission submission;
+    submission.damageSource = impl_->damageAccumulator;
     submission.enqueuedAtUs = steadyNowUs();
     if (!impl_->framePump.submitLatest(std::move(submission))) {
         OH_LOG_WARN(LOG_APP, "[RDP] requestFrameRefresh skipped: frame pump unavailable");

--- a/entry/src/main/cpp/rdp/rdp_damage_accumulator.cpp
+++ b/entry/src/main/cpp/rdp/rdp_damage_accumulator.cpp
@@ -1,0 +1,216 @@
+#include "rdp_damage_accumulator.h"
+
+#include <algorithm>
+#include <cstring>
+#include <new>
+
+RdpDamageRect RdpDamageAccumulator::ClipRect(int frameWidth, int frameHeight,
+                                             int x, int y, int width, int height) {
+    RdpDamageRect result;
+    if (frameWidth <= 0 || frameHeight <= 0 || width <= 0 || height <= 0) {
+        return result;
+    }
+
+    const int64_t left = std::max<int64_t>(0, x);
+    const int64_t top = std::max<int64_t>(0, y);
+    const int64_t right = std::min<int64_t>(frameWidth,
+        static_cast<int64_t>(x) + static_cast<int64_t>(width));
+    const int64_t bottom = std::min<int64_t>(frameHeight,
+        static_cast<int64_t>(y) + static_cast<int64_t>(height));
+    if (right <= left || bottom <= top) {
+        return result;
+    }
+
+    result.x = static_cast<int>(left);
+    result.y = static_cast<int>(top);
+    result.width = static_cast<int>(right - left);
+    result.height = static_cast<int>(bottom - top);
+    result.valid = true;
+    return result;
+}
+
+RdpDamageRect RdpDamageAccumulator::UnionRect(const RdpDamageRect& left,
+                                              const RdpDamageRect& right) {
+    if (!left.valid) {
+        return right;
+    }
+    if (!right.valid) {
+        return left;
+    }
+    RdpDamageRect result;
+    result.x = std::min(left.x, right.x);
+    result.y = std::min(left.y, right.y);
+    const int maxX = std::max(left.x + left.width, right.x + right.width);
+    const int maxY = std::max(left.y + left.height, right.y + right.height);
+    result.width = maxX - result.x;
+    result.height = maxY - result.y;
+    result.valid = result.width > 0 && result.height > 0;
+    return result;
+}
+
+bool RdpDamageAccumulator::CoversFullThreshold(const RdpDamageRect& rect,
+                                               int frameWidth, int frameHeight) {
+    if (!rect.valid || frameWidth <= 0 || frameHeight <= 0) {
+        return false;
+    }
+    const uint64_t damagePixels = static_cast<uint64_t>(rect.width) *
+        static_cast<uint64_t>(rect.height);
+    const uint64_t framePixels = static_cast<uint64_t>(frameWidth) *
+        static_cast<uint64_t>(frameHeight);
+    return damagePixels * 100U >= framePixels * kFullFrameThresholdPercent;
+}
+
+RdpDamageUpdateResult RdpDamageAccumulator::update(
+    const uint8_t* data, size_t size, int width, int height, int sourceStride,
+    int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight,
+    uint64_t rendererGeneration, bool forceFullResync) {
+    RdpDamageUpdateResult result;
+    if (!data || width <= 0 || height <= 0 || sourceStride < width * 4 ||
+        rendererGeneration == 0) {
+        return result;
+    }
+    const size_t requiredSourceBytes =
+        static_cast<size_t>(height - 1) * static_cast<size_t>(sourceStride) +
+        static_cast<size_t>(width) * 4U;
+    if (requiredSourceBytes > size) {
+        return result;
+    }
+
+    const RdpDamageRect clipped = ClipRect(
+        width, height, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
+    std::lock_guard<std::mutex> lock(mutex_);
+    const bool geometryChanged = width_ != width || height_ != height ||
+        stride_ != width * 4 || staging_.size() !=
+            static_cast<size_t>(width) * static_cast<size_t>(height) * 4U;
+    const bool generationChanged = rendererGeneration_ != rendererGeneration;
+    const bool fullResync = forceFullResync || geometryChanged || generationChanged ||
+        !clipped.valid;
+
+    const int tightStride = width * 4;
+    try {
+        if (fullResync) {
+            std::vector<uint8_t> replacement(
+                static_cast<size_t>(tightStride) * static_cast<size_t>(height));
+            for (int row = 0; row < height; ++row) {
+                std::memcpy(replacement.data() +
+                                static_cast<size_t>(row) * static_cast<size_t>(tightStride),
+                            data + static_cast<size_t>(row) * static_cast<size_t>(sourceStride),
+                            static_cast<size_t>(tightStride));
+            }
+            staging_.swap(replacement);
+            width_ = width;
+            height_ = height;
+            stride_ = tightStride;
+            rendererGeneration_ = rendererGeneration;
+            pendingDamage_ = {0, 0, width, height, true};
+            pendingFullFrame_ = true;
+            result.copiedBytes = static_cast<uint64_t>(tightStride) *
+                static_cast<uint64_t>(height);
+        } else {
+            const size_t rowBytes = static_cast<size_t>(clipped.width) * 4U;
+            for (int row = 0; row < clipped.height; ++row) {
+                const size_t sourceOffset =
+                    static_cast<size_t>(clipped.y + row) * static_cast<size_t>(sourceStride) +
+                    static_cast<size_t>(clipped.x) * 4U;
+                const size_t destinationOffset =
+                    static_cast<size_t>(clipped.y + row) * static_cast<size_t>(stride_) +
+                    static_cast<size_t>(clipped.x) * 4U;
+                std::memcpy(staging_.data() + destinationOffset, data + sourceOffset, rowBytes);
+            }
+            pendingDamage_ = UnionRect(pendingDamage_, clipped);
+            result.copiedBytes = static_cast<uint64_t>(rowBytes) *
+                static_cast<uint64_t>(clipped.height);
+            if (CoversFullThreshold(pendingDamage_, width_, height_)) {
+                pendingDamage_ = {0, 0, width_, height_, true};
+                pendingFullFrame_ = true;
+            }
+        }
+    } catch (const std::bad_alloc&) {
+        result.allocationFailed = true;
+        return result;
+    } catch (...) {
+        result.allocationFailed = true;
+        return result;
+    }
+
+    result.accepted = true;
+    result.fullResync = fullResync || pendingFullFrame_;
+    return result;
+}
+
+bool RdpDamageAccumulator::requestFullSnapshot(uint64_t rendererGeneration) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (rendererGeneration == 0 || staging_.empty() || width_ <= 0 || height_ <= 0) {
+        return false;
+    }
+    rendererGeneration_ = rendererGeneration;
+    pendingDamage_ = {0, 0, width_, height_, true};
+    pendingFullFrame_ = true;
+    return true;
+}
+
+RdpDamageSnapshot RdpDamageAccumulator::takeSnapshot() {
+    RdpDamageSnapshot snapshot;
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!pendingDamage_.valid || staging_.empty()) {
+        return snapshot;
+    }
+
+    const bool fullFrame = pendingFullFrame_;
+    const RdpDamageRect damage = fullFrame ?
+        RdpDamageRect{0, 0, width_, height_, true} : pendingDamage_;
+    const int snapshotStride = damage.width * 4;
+    const size_t snapshotBytes = static_cast<size_t>(snapshotStride) *
+        static_cast<size_t>(damage.height);
+    if (snapshotBytes > snapshotAllocationLimit_) {
+        return snapshot;
+    }
+
+    try {
+        snapshot.pixels.resize(snapshotBytes);
+    } catch (...) {
+        return RdpDamageSnapshot();
+    }
+    for (int row = 0; row < damage.height; ++row) {
+        const size_t sourceOffset =
+            static_cast<size_t>(damage.y + row) * static_cast<size_t>(stride_) +
+            static_cast<size_t>(damage.x) * 4U;
+        std::memcpy(snapshot.pixels.data() +
+                        static_cast<size_t>(row) * static_cast<size_t>(snapshotStride),
+                    staging_.data() + sourceOffset,
+                    static_cast<size_t>(snapshotStride));
+    }
+
+    snapshot.valid = true;
+    snapshot.fullFrame = fullFrame;
+    snapshot.width = width_;
+    snapshot.height = height_;
+    snapshot.stride = snapshotStride;
+    snapshot.damage = damage;
+    snapshot.rendererGeneration = rendererGeneration_;
+    snapshot.snapshotCopiedBytes = snapshotBytes;
+    pendingDamage_ = RdpDamageRect();
+    pendingFullFrame_ = false;
+    return snapshot;
+}
+
+void RdpDamageAccumulator::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    staging_.clear();
+    width_ = 0;
+    height_ = 0;
+    stride_ = 0;
+    rendererGeneration_ = 0;
+    pendingDamage_ = RdpDamageRect();
+    pendingFullFrame_ = false;
+}
+
+bool RdpDamageAccumulator::hasPending() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return pendingDamage_.valid;
+}
+
+void RdpDamageAccumulator::setSnapshotAllocationLimitForTest(size_t limit) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    snapshotAllocationLimit_ = limit;
+}

--- a/entry/src/main/cpp/rdp/rdp_damage_accumulator.h
+++ b/entry/src/main/cpp/rdp/rdp_damage_accumulator.h
@@ -1,0 +1,71 @@
+#ifndef RDP_DAMAGE_ACCUMULATOR_H
+#define RDP_DAMAGE_ACCUMULATOR_H
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <mutex>
+#include <vector>
+
+struct RdpDamageRect {
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+    bool valid = false;
+};
+
+struct RdpDamageUpdateResult {
+    bool accepted = false;
+    bool fullResync = false;
+    bool allocationFailed = false;
+    uint64_t copiedBytes = 0;
+};
+
+struct RdpDamageSnapshot {
+    bool valid = false;
+    bool fullFrame = false;
+    std::vector<uint8_t> pixels;
+    int width = 0;
+    int height = 0;
+    int stride = 0;
+    RdpDamageRect damage;
+    uint64_t rendererGeneration = 0;
+    uint64_t snapshotCopiedBytes = 0;
+};
+
+class RdpDamageAccumulator {
+public:
+    static constexpr uint64_t kFullFrameThresholdPercent = 70;
+
+    static RdpDamageRect ClipRect(int frameWidth, int frameHeight,
+                                  int x, int y, int width, int height);
+
+    RdpDamageUpdateResult update(const uint8_t* data, size_t size,
+                                 int width, int height, int sourceStride,
+                                 int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight,
+                                 uint64_t rendererGeneration, bool forceFullResync);
+    bool requestFullSnapshot(uint64_t rendererGeneration);
+    RdpDamageSnapshot takeSnapshot();
+    void clear();
+    bool hasPending() const;
+    void setSnapshotAllocationLimitForTest(size_t limit);
+
+private:
+    static RdpDamageRect UnionRect(const RdpDamageRect& left,
+                                   const RdpDamageRect& right);
+    static bool CoversFullThreshold(const RdpDamageRect& rect,
+                                    int frameWidth, int frameHeight);
+
+    mutable std::mutex mutex_;
+    std::vector<uint8_t> staging_;
+    int width_ = 0;
+    int height_ = 0;
+    int stride_ = 0;
+    uint64_t rendererGeneration_ = 0;
+    RdpDamageRect pendingDamage_;
+    bool pendingFullFrame_ = false;
+    size_t snapshotAllocationLimit_ = std::numeric_limits<size_t>::max();
+};
+
+#endif // RDP_DAMAGE_ACCUMULATOR_H

--- a/entry/src/main/cpp/rdp/rdp_frame_pump.cpp
+++ b/entry/src/main/cpp/rdp/rdp_frame_pump.cpp
@@ -78,8 +78,10 @@ void RdpFramePump::stop() {
 }
 
 bool RdpFramePump::submitLatest(RdpFrameSubmission&& submission) {
-    if (submission.pixels.empty() || submission.width <= 0 || submission.height <= 0 ||
-        submission.stride <= 0 || submission.rendererGeneration == 0) {
+    const bool validOwnedPixels = !submission.pixels.empty() &&
+        submission.width > 0 && submission.height > 0 && submission.stride > 0 &&
+        submission.rendererGeneration != 0;
+    if (!submission.damageSource && !validOwnedPixels) {
         return false;
     }
 
@@ -150,8 +152,30 @@ void RdpFramePump::loop() {
         present.generation = frame.rendererGeneration;
         const int64_t queueWaitUs =
             frame.enqueuedAtUs > 0 ? SteadyNowUs() - frame.enqueuedAtUs : 0;
+        if (frame.damageSource) {
+            const int64_t snapshotBeginUs = SteadyNowUs();
+            RdpDamageSnapshot snapshot = frame.damageSource->takeSnapshot();
+            const int64_t snapshotCopyUs = SteadyNowUs() - snapshotBeginUs;
+            if (snapshot.valid) {
+                metrics_.recordCopy(SteadyNowUs(), snapshot.snapshotCopiedBytes, snapshotCopyUs);
+                frame.pixels = std::move(snapshot.pixels);
+                frame.width = snapshot.width;
+                frame.height = snapshot.height;
+                frame.stride = snapshot.stride;
+                frame.dirtyX = snapshot.damage.x;
+                frame.dirtyY = snapshot.damage.y;
+                frame.dirtyWidth = snapshot.damage.width;
+                frame.dirtyHeight = snapshot.damage.height;
+                frame.dirtyValid = !snapshot.fullFrame;
+                frame.rendererGeneration = snapshot.rendererGeneration;
+            }
+        }
         try {
-            present = frame.dirtyValid ?
+            if (frame.pixels.empty()) {
+                present.result = RdpPresentResult::InvalidFrame;
+                present.generation = frame.rendererGeneration;
+            } else {
+                present = frame.dirtyValid ?
                 RendererNapi::PresentRawBgraRectActive(
                     frame.pixels.data(), frame.pixels.size(), frame.width, frame.height,
                     frame.stride, frame.dirtyX, frame.dirtyY, frame.dirtyWidth,
@@ -159,6 +183,7 @@ void RdpFramePump::loop() {
                 RendererNapi::PresentRawBgraActive(
                     frame.pixels.data(), frame.pixels.size(), frame.width, frame.height,
                     frame.stride, frame.rendererGeneration);
+            }
             present.queueWaitUs = queueWaitUs;
         } catch (const std::exception& e) {
             present.result = RdpPresentResult::Exception;
@@ -175,7 +200,8 @@ void RdpFramePump::loop() {
             rejected_.fetch_add(1, std::memory_order_relaxed);
             if (present.result == RdpPresentResult::SurfaceDetached ||
                 present.result == RdpPresentResult::GenerationMismatch ||
-                present.result == RdpPresentResult::RendererNotReady) {
+                present.result == RdpPresentResult::RendererNotReady ||
+                present.result == RdpPresentResult::InvalidFrame) {
                 fullResyncRequired_.store(true, std::memory_order_release);
             }
         }
@@ -207,6 +233,10 @@ void RdpFramePump::loop() {
 
 void RdpFramePump::recordInvalid(uint64_t pixels, int64_t callbackUs, int64_t nowUs) {
     metrics_.recordInvalid(nowUs, pixels, callbackUs);
+}
+
+void RdpFramePump::recordCopy(uint64_t copiedBytes, int64_t copyUs, int64_t nowUs) {
+    metrics_.recordCopy(nowUs, copiedBytes, copyUs);
 }
 
 void RdpFramePump::recordDirectPresent(const RdpPresentMetrics& present, int64_t nowUs) {

--- a/entry/src/main/cpp/rdp/rdp_frame_pump.h
+++ b/entry/src/main/cpp/rdp/rdp_frame_pump.h
@@ -6,17 +6,20 @@
 #define RDP_FRAME_PUMP_H
 
 #include "rdp_presentation_metrics.h"
+#include "rdp_damage_accumulator.h"
 
 #include <atomic>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
+#include <memory>
 #include <thread>
 #include <vector>
 
 struct RdpFrameSubmission {
     std::vector<uint8_t> pixels;
+    std::shared_ptr<RdpDamageAccumulator> damageSource;
     int width = 0;
     int height = 0;
     int stride = 0;
@@ -45,6 +48,7 @@ public:
     bool isRunning() const;
 
     void recordInvalid(uint64_t pixels, int64_t callbackUs, int64_t nowUs);
+    void recordCopy(uint64_t copiedBytes, int64_t copyUs, int64_t nowUs);
     void recordDirectPresent(const RdpPresentMetrics& present, int64_t nowUs);
     RdpPresentationMetricsSnapshot metricsSnapshot(int64_t nowUs);
     int64_t lastWorkerCostUs() const;

--- a/entry/src/main/cpp/rdp/rdp_presentation_metrics.h
+++ b/entry/src/main/cpp/rdp/rdp_presentation_metrics.h
@@ -111,6 +111,14 @@ public:
         (void)callbackUs;
     }
 
+    void recordCopy(int64_t nowUs, uint64_t copiedBytes, int64_t copyUs) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        rollWindowLocked(nowUs);
+        totals_.copiedBytes += copiedBytes;
+        current_.copiedBytes += copiedBytes;
+        appendNonNegative(current_.copyUs, copyUs);
+    }
+
     void recordPresent(int64_t nowUs, const RdpPresentMetrics& present) {
         std::lock_guard<std::mutex> lock(mutex_);
         rollWindowLocked(nowUs);

--- a/entry/src/main/cpp/test/rdp_damage_accumulator_test.cpp
+++ b/entry/src/main/cpp/test/rdp_damage_accumulator_test.cpp
@@ -1,0 +1,148 @@
+#include "test_runner.h"
+#include "rdp/rdp_damage_accumulator.h"
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace {
+
+std::vector<uint8_t> MakeFrame(int width, int height, int stride, uint8_t seed) {
+    std::vector<uint8_t> frame(static_cast<size_t>(stride) * static_cast<size_t>(height), 0xEE);
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            const size_t offset = static_cast<size_t>(y) * static_cast<size_t>(stride) +
+                static_cast<size_t>(x) * 4U;
+            frame[offset] = static_cast<uint8_t>(seed + y * width + x);
+            frame[offset + 1] = static_cast<uint8_t>(x);
+            frame[offset + 2] = static_cast<uint8_t>(y);
+            frame[offset + 3] = 0xFF;
+        }
+    }
+    return frame;
+}
+
+} // namespace
+
+RDP_TEST_CASE(rdp_damage_accumulator_clips_rect_to_frame) {
+    const RdpDamageRect clipped = RdpDamageAccumulator::ClipRect(10, 8, -2, 6, 6, 5);
+    RDP_ASSERT(clipped.valid);
+    RDP_ASSERT_EQ(clipped.x, 0);
+    RDP_ASSERT_EQ(clipped.y, 6);
+    RDP_ASSERT_EQ(clipped.width, 4);
+    RDP_ASSERT_EQ(clipped.height, 2);
+}
+
+RDP_TEST_CASE(rdp_damage_accumulator_unions_replacements_from_latest_staging) {
+    RdpDamageAccumulator accumulator;
+    std::vector<uint8_t> frame = MakeFrame(4, 3, 16, 10);
+    RDP_ASSERT(accumulator.update(frame.data(), frame.size(), 4, 3, 16,
+                                  0, 0, 4, 3, 1, false).accepted);
+    RDP_ASSERT(accumulator.takeSnapshot().fullFrame);
+
+    frame = MakeFrame(4, 3, 16, 40);
+    RDP_ASSERT(accumulator.update(frame.data(), frame.size(), 4, 3, 16,
+                                  1, 1, 2, 1, 1, false).accepted);
+    RDP_ASSERT(accumulator.update(frame.data(), frame.size(), 4, 3, 16,
+                                  0, 2, 1, 1, 1, false).accepted);
+    const RdpDamageSnapshot snapshot = accumulator.takeSnapshot();
+
+    RDP_ASSERT(snapshot.valid);
+    RDP_ASSERT(!snapshot.fullFrame);
+    RDP_ASSERT_EQ(snapshot.damage.x, 0);
+    RDP_ASSERT_EQ(snapshot.damage.y, 1);
+    RDP_ASSERT_EQ(snapshot.damage.width, 3);
+    RDP_ASSERT_EQ(snapshot.damage.height, 2);
+    RDP_ASSERT_EQ(snapshot.stride, 12);
+    RDP_ASSERT_EQ(snapshot.pixels[4], static_cast<uint8_t>(45));
+    RDP_ASSERT_EQ(snapshot.pixels[8], static_cast<uint8_t>(46));
+    RDP_ASSERT_EQ(snapshot.pixels[12], static_cast<uint8_t>(48));
+}
+
+RDP_TEST_CASE(rdp_damage_accumulator_generation_change_forces_full_resync) {
+    RdpDamageAccumulator accumulator;
+    std::vector<uint8_t> frame = MakeFrame(4, 4, 16, 1);
+    accumulator.update(frame.data(), frame.size(), 4, 4, 16, 0, 0, 4, 4, 1, false);
+    accumulator.takeSnapshot();
+
+    const RdpDamageUpdateResult update = accumulator.update(
+        frame.data(), frame.size(), 4, 4, 16, 1, 1, 1, 1, 2, false);
+    RDP_ASSERT(update.accepted);
+    RDP_ASSERT(update.fullResync);
+    RDP_ASSERT(accumulator.takeSnapshot().fullFrame);
+}
+
+RDP_TEST_CASE(rdp_damage_accumulator_invalid_rect_recovers_current_full_frame) {
+    RdpDamageAccumulator accumulator;
+    std::vector<uint8_t> frame = MakeFrame(4, 3, 16, 1);
+    accumulator.update(frame.data(), frame.size(), 4, 3, 16, 0, 0, 4, 3, 1, false);
+    accumulator.takeSnapshot();
+
+    frame = MakeFrame(4, 3, 16, 30);
+    const RdpDamageUpdateResult update = accumulator.update(
+        frame.data(), frame.size(), 4, 3, 16, 8, 8, 2, 2, 1, false);
+    RDP_ASSERT(update.accepted);
+    RDP_ASSERT(update.fullResync);
+    const RdpDamageSnapshot snapshot = accumulator.takeSnapshot();
+    RDP_ASSERT(snapshot.fullFrame);
+    RDP_ASSERT_EQ(snapshot.pixels[0], static_cast<uint8_t>(30));
+}
+
+RDP_TEST_CASE(rdp_damage_accumulator_refresh_uses_owned_staging) {
+    RdpDamageAccumulator accumulator;
+    std::vector<uint8_t> frame = MakeFrame(3, 2, 12, 9);
+    accumulator.update(frame.data(), frame.size(), 3, 2, 12, 0, 0, 3, 2, 1, false);
+    accumulator.takeSnapshot();
+
+    frame.assign(frame.size(), 0xFE);
+    RDP_ASSERT(accumulator.requestFullSnapshot(2));
+    const RdpDamageSnapshot snapshot = accumulator.takeSnapshot();
+    RDP_ASSERT(snapshot.valid);
+    RDP_ASSERT(snapshot.fullFrame);
+    RDP_ASSERT_EQ(snapshot.rendererGeneration, static_cast<uint64_t>(2));
+    RDP_ASSERT_EQ(snapshot.pixels[0], static_cast<uint8_t>(9));
+    RDP_ASSERT_EQ(snapshot.pixels[12], static_cast<uint8_t>(12));
+}
+
+RDP_TEST_CASE(rdp_damage_accumulator_resize_copies_tight_rows_without_padding) {
+    RdpDamageAccumulator accumulator;
+    std::vector<uint8_t> first = MakeFrame(2, 2, 12, 1);
+    accumulator.update(first.data(), first.size(), 2, 2, 12, 0, 0, 2, 2, 1, false);
+    RdpDamageSnapshot snapshot = accumulator.takeSnapshot();
+    RDP_ASSERT_EQ(snapshot.stride, 8);
+    RDP_ASSERT_EQ(snapshot.pixels.size(), static_cast<size_t>(16));
+
+    std::vector<uint8_t> resized = MakeFrame(3, 2, 16, 20);
+    const RdpDamageUpdateResult update = accumulator.update(
+        resized.data(), resized.size(), 3, 2, 16, 2, 1, 1, 1, 1, false);
+    RDP_ASSERT(update.fullResync);
+    snapshot = accumulator.takeSnapshot();
+    RDP_ASSERT(snapshot.fullFrame);
+    RDP_ASSERT_EQ(snapshot.stride, 12);
+    RDP_ASSERT_EQ(snapshot.pixels.size(), static_cast<size_t>(24));
+    RDP_ASSERT_EQ(snapshot.pixels[12], static_cast<uint8_t>(23));
+}
+
+RDP_TEST_CASE(rdp_damage_accumulator_escalates_union_at_seventy_percent) {
+    RdpDamageAccumulator accumulator;
+    std::vector<uint8_t> frame = MakeFrame(10, 10, 40, 1);
+    accumulator.update(frame.data(), frame.size(), 10, 10, 40, 0, 0, 10, 10, 1, false);
+    accumulator.takeSnapshot();
+    accumulator.update(frame.data(), frame.size(), 10, 10, 40, 0, 0, 8, 9, 1, false);
+    RDP_ASSERT(accumulator.takeSnapshot().fullFrame);
+}
+
+RDP_TEST_CASE(rdp_damage_accumulator_snapshot_failure_keeps_pending_damage) {
+    RdpDamageAccumulator accumulator;
+    std::vector<uint8_t> frame = MakeFrame(4, 4, 16, 1);
+    accumulator.update(frame.data(), frame.size(), 4, 4, 16, 0, 0, 4, 4, 1, false);
+    accumulator.takeSnapshot();
+    accumulator.update(frame.data(), frame.size(), 4, 4, 16, 1, 1, 1, 1, 1, false);
+
+    accumulator.setSnapshotAllocationLimitForTest(1);
+    RDP_ASSERT(!accumulator.takeSnapshot().valid);
+    RDP_ASSERT(accumulator.hasPending());
+    accumulator.setSnapshotAllocationLimitForTest(std::numeric_limits<size_t>::max());
+    RDP_ASSERT(accumulator.takeSnapshot().valid);
+    RDP_ASSERT(!accumulator.hasPending());
+}


### PR DESCRIPTION
## Summary
- add an owned BGRA damage accumulator with clipped dirty-row updates and compact worker snapshots
- preserve latest damage across queue replacement, resize, generation changes, invalid rectangles, and allocation failures
- route explicit frame refresh through owned staging instead of reading FreeRDP GDI memory from the UI thread

## Verification
- native tests: 91 passed, 0 failed
- default@OhosTestCompileArkTS: BUILD SUCCESSFUL
- assembleHap: BUILD SUCCESSFUL (arm64-v8a and x86_64)
- open-source Light gate: passed
- emulator install/start: passed, no fatal/SIGSEGV/presentation generation errors