### PR TITLE
fix: stabilize feedback QR and SSH reconnect terminal

### DIFF
--- a/docs/feedback-community-qr.md
+++ b/docs/feedback-community-qr.md
@@ -2,9 +2,9 @@
 
 反馈页从公开 HTTPS 清单读取二维码，不把二维码图片或邀请链接打包进应用。默认地址为：
 
-`https://mydstiny.github.io/RemoteDeskHarmonyOS/feedback/chanlian.json`
+`https://lijiong.online/feedback/chanlian.json`
 
-当前线上文件位于 `docs/feedback/chanlian-current.jpg` 和 `docs/feedback/chanlian.json`。GitHub Pages 工作流只发布 `docs/feedback` 下的这三个静态文件，不发布仓库其他文档。
+当前线上文件位于 Hexo 站点的 `source/feedback/chanlian-current.jpg` 和 `source/feedback/chanlian.json`，由 `https://lijiong.online/feedback/` 提供。仓库中的 `docs/feedback` 保留为版本化源文件和 GitHub Pages 备用镜像，不发布仓库其他文档。
 
 每次更新群二维码时，替换 `chanlian-current.jpg` 和 `chanlian.json` 中的时间、提示文案。时间戳使用 Unix 毫秒，`expiresAt - issuedAt` 不得超过 7 天：
 
@@ -12,7 +12,7 @@
 {
   "issuedAt": 1783987200000,
   "expiresAt": 1784592000000,
-  "qrImageUrl": "https://mydstiny.github.io/RemoteDeskHarmonyOS/feedback/chanlian-current.jpg",
+  "qrImageUrl": "https://lijiong.online/feedback/chanlian-current.jpg",
   "joinUrl": "",
   "title": "加入 RemoteDesktop 畅联群聊",
   "notice": "二维码每 7 天更新一次，请保存后使用另一台设备扫描。"
@@ -21,6 +21,6 @@
 
 `joinUrl` 是可选项。建议使用华为 App Linking 或你维护的 HTTPS 落地页；畅连没有在公开开发者文档中承诺一个可跨版本使用的群聊 URI，因此应用只在清单提供该链接时尝试直接跳转，失败后仍可保存二维码扫描。
 
-首次启用前，在仓库 Settings → Pages 中将 Source 设置为 **GitHub Actions**。GitHub Pages 会通过 HTTPS 提供 `https://mydstiny.github.io/RemoteDeskHarmonyOS/feedback/chanlian.json`；GitHub 官方说明所有 `github.io` Pages 站点支持 HTTPS，且可以用 Actions 发布静态 artifact。
+服务器更新流程：将 `chanlian-current.jpg` 和 `chanlian.json` 上传到 Hexo 的 `source/feedback/`，在 `/www/wwwroot/hexo` 执行 `npm run build`。更新后验证 `https://lijiong.online/feedback/chanlian.json` 和图片地址均返回 200。GitHub Pages 工作流仍可作为海外备用镜像，但不再是客户端主地址。
 
 二维码是公开入群凭证，不要把管理员口令、私有 API token 或其他敏感信息写入图片、JSON 或仓库。旧图片虽然不再由当前路径引用，但仍可能存在 Git 历史中；因此每次轮换后应让畅连侧的旧二维码立即失效，并保持 7 天上限。

--- a/docs/feedback/chanlian.json
+++ b/docs/feedback/chanlian.json
@@ -1,7 +1,7 @@
 {
   "issuedAt": 1783958400000,
   "expiresAt": 1784563200000,
-  "qrImageUrl": "https://mydstiny.github.io/RemoteDeskHarmonyOS/feedback/chanlian-current.jpg",
+  "qrImageUrl": "https://lijiong.online/feedback/chanlian-current.jpg",
   "joinUrl": "",
   "title": "加入 RemoteDesktop 畅联群聊",
   "notice": "二维码有效期至 2026 年 7 月 21 日，请保存后使用另一台设备扫描。"

--- a/entry/src/main/cpp/ssh/ssh_adapter.cpp
+++ b/entry/src/main/cpp/ssh/ssh_adapter.cpp
@@ -513,6 +513,12 @@ void SshAdapter::disconnect() {
     // 先停 reader 线程, 避免后续 channel/session free 时的竞态
     stopReader();
 
+    {
+        std::lock_guard<std::mutex> callbackLock(callbackMutex_);
+        onDataCallback_ = nullptr;
+        pendingData_.clear();
+    }
+
     std::lock_guard<std::mutex> sessionLock(sessionMutex_);
     if (sftp_) {
         libssh2_sftp_shutdown(sftp_);
@@ -1071,6 +1077,9 @@ int SshAdapter::measureLatencyMs() {
 void SshAdapter::setOnDataCallback(DataCallback cb) {
     std::lock_guard<std::mutex> lk(callbackMutex_);
     onDataCallback_ = std::move(cb);
+    if (!onDataCallback_) {
+        pendingData_.clear();
+    }
     OH_LOG_INFO(LOG_APP, "[SSH] onDataCallback %{public}s",
                 onDataCallback_ ? "已注册" : "已清除");
 }
@@ -1096,6 +1105,7 @@ void SshAdapter::stopReader() {
 
 void SshAdapter::readerLoop() {
     constexpr size_t kBufSize = SSH_BUFFER_SIZE;
+    constexpr size_t kMaxPendingData = SSH_BUFFER_SIZE * 4;
     std::vector<uint8_t> buf(kBufSize);
 
     while (readerRunning_.load()) {
@@ -1107,6 +1117,21 @@ void SshAdapter::readerLoop() {
             struct timeval tv = {0, 100 * 1000};  // 100ms
             select(0, nullptr, nullptr, nullptr, &tv);
             continue;
+        }
+
+        // connect() 会先启动 reader, ArkTS 只能在 connect() 返回后注册回调。
+        // 把这段空窗期收到的登录 banner 延迟到回调就绪后再发送，避免首次连接丢首屏。
+        DataCallback pendingCb;
+        std::string pending;
+        {
+            std::lock_guard<std::mutex> lk(callbackMutex_);
+            if (onDataCallback_ && !pendingData_.empty()) {
+                pendingCb = onDataCallback_;
+                pending.swap(pendingData_);
+            }
+        }
+        if (pendingCb && !pending.empty()) {
+            try { pendingCb(pending); } catch (...) { /* 静默, 不中断 reader */ }
         }
 
         // 100ms select 等待 socket 可读
@@ -1151,12 +1176,22 @@ void SshAdapter::readerLoop() {
 
         if (gotData && !accumulated.empty()) {
             DataCallback cb;
+            std::string dataToDeliver;
             {
                 std::lock_guard<std::mutex> lk(callbackMutex_);
-                cb = onDataCallback_;
+                if (onDataCallback_) {
+                    cb = onDataCallback_;
+                    dataToDeliver.swap(pendingData_);
+                    dataToDeliver.append(accumulated);
+                } else {
+                    pendingData_.append(accumulated);
+                    if (pendingData_.size() > kMaxPendingData) {
+                        pendingData_.erase(0, pendingData_.size() - kMaxPendingData);
+                    }
+                }
             }
             if (cb) {
-                try { cb(accumulated); } catch (...) { /* 静默, 不中断 reader */ }
+                try { cb(dataToDeliver); } catch (...) { /* 静默, 不中断 reader */ }
             }
         }
     }

--- a/entry/src/main/cpp/ssh/ssh_adapter.h
+++ b/entry/src/main/cpp/ssh/ssh_adapter.h
@@ -175,6 +175,7 @@ private:
     std::thread        readerThread_;
     std::atomic<bool>  readerRunning_{false};
     DataCallback       onDataCallback_;
+    std::string        pendingData_;             // 回调注册前到达的首批 shell 输出
     std::mutex         callbackMutex_;          // 保护 onDataCallback_
     std::mutex         sessionMutex_;           // 串行化 libssh2 session/channel 操作
 

--- a/entry/src/main/ets/components/FeedbackSettingsSheet.ets
+++ b/entry/src/main/ets/components/FeedbackSettingsSheet.ets
@@ -3,7 +3,6 @@
  */
 import { promptAction } from '@kit.ArkUI';
 import { common, Want } from '@kit.AbilityKit';
-import { fileIo } from '@kit.CoreFileKit';
 import { image } from '@kit.ImageKit';
 import { photoAccessHelper } from '@kit.MediaLibraryKit';
 import { HdsTabs, HdsTabsController } from '@kit.UIDesignKit';
@@ -58,6 +57,15 @@ export struct FeedbackSettingsSheet {
   private errorMessage(error: Object): string {
     if (error instanceof Error && error.message !== '') {
       return error.message;
+    }
+    const details: Record<string, Object> = error as Record<string, Object>;
+    const message: Object | undefined = details['message'];
+    const code: Object | undefined = details['code'];
+    if (typeof message === 'string' && (message as string) !== '') {
+      if (typeof code === 'number') {
+        return '错误码 ' + (code as number).toString() + '：' + (message as string);
+      }
+      return message as string;
     }
     return '暂时无法读取云端二维码，请稍后重试。';
   }
@@ -129,7 +137,10 @@ export struct FeedbackSettingsSheet {
   }
 
   private async saveQrImage(result: SaveButtonOnClickResult): Promise<void> {
-    if (result !== SaveButtonOnClickResult.SUCCESS) { return; }
+    if (result !== SaveButtonOnClickResult.SUCCESS) {
+      promptAction.showToast({ message: '未获得相册保存授权，请重试', duration: 2200 });
+      return;
+    }
     const manifest: FeedbackCommunityManifest | null = this.community;
     if (manifest === null || this.savingQr) { return; }
     this.savingQr = true;
@@ -139,14 +150,15 @@ export struct FeedbackSettingsSheet {
       );
       const ctx: common.UIAbilityContext = getContext(this) as common.UIAbilityContext;
       const helper = photoAccessHelper.getPhotoAccessHelper(ctx);
-      const uri: string = await helper.createAsset(photoAccessHelper.PhotoType.IMAGE, 'png');
-      const file = fileIo.openSync(uri, fileIo.OpenMode.READ_WRITE | fileIo.OpenMode.CREATE);
-      try {
-        const written: number = fileIo.writeSync(file.fd, bytes);
-        if (written <= 0) { throw new Error('二维码文件写入失败'); }
-      } finally {
-        fileIo.closeSync(file);
-      }
+      const assetChangeRequest: photoAccessHelper.MediaAssetChangeRequest =
+        photoAccessHelper.MediaAssetChangeRequest.createAssetRequest(
+          ctx,
+          photoAccessHelper.PhotoType.IMAGE,
+          'jpg',
+          { title: '畅联群聊二维码' }
+        );
+      assetChangeRequest.addResource(photoAccessHelper.ResourceType.IMAGE_RESOURCE, bytes);
+      await helper.applyChanges(assetChangeRequest);
       promptAction.showToast({ message: '二维码已保存到相册', duration: 1800 });
     } catch (error) {
       promptAction.showToast({ message: '保存失败：' + this.errorMessage(error as Object), duration: 2400 });

--- a/entry/src/main/ets/components/NativeTerminalRenderer.ets
+++ b/entry/src/main/ets/components/NativeTerminalRenderer.ets
@@ -80,6 +80,7 @@ export struct NativeTerminalRenderer {
   private lastGridTop: number = 0;
 
   aboutToAppear(): void {
+    this.resetLifecycleState();
     this.lastRows = this.rows;
     this.calcCellSize();
     this.handle = this.bridge.create(this.cols, this.rows);
@@ -99,6 +100,21 @@ export struct NativeTerminalRenderer {
       this.bridge.destroy(this.handle);
       this.handle = 0;
     }
+    this.resetLifecycleState();
+  }
+
+  /** ArkUI 可能复用组件实例；Rust handle 重建时增量游标也必须同步归零。 */
+  private resetLifecycleState(): void {
+    this.lastSnapshot = null;
+    this.dirtyRows.clear();
+    this.cursorVisible = true;
+    this.lastCursorX = 0;
+    this.lastCursorY = 0;
+    this.lastInputLen = 0;
+    this.followBottom = true;
+    this.frameCount = 0;
+    this.lastGridTop = 0;
+    this.lastViewportHeight = 0;
   }
 
   // ============================================================

--- a/entry/src/main/ets/components/TerminalEmulator.ets
+++ b/entry/src/main/ets/components/TerminalEmulator.ets
@@ -247,6 +247,7 @@ export struct TerminalEmulator {
   private lastViewportHeight: number = 0;
 
   aboutToAppear(): void {
+    this.resetLifecycleState();
     this.scrollBottom = this.rows - 1;
     this.lastRows = this.rows;
     this.fgColor = this.terminalFgColor;
@@ -264,6 +265,20 @@ export struct TerminalEmulator {
       clearInterval(this.blinkTimer);
       this.blinkTimer = -1;
     }
+    this.resetLifecycleState();
+  }
+
+  /** ArkUI 复用组件时清除上一 SSH 会话的增量、滚动和选择状态。 */
+  private resetLifecycleState(): void {
+    this.lastInputLen = 0;
+    this.followBottom = true;
+    this.lastGridTop = 0;
+    this.lastViewportHeight = 0;
+    this.cursorVisible = true;
+    this.lastCursorX = 0;
+    this.lastCursorAbsR = 0;
+    this.clearSelection();
+    this.resetTerminalState();
   }
 
   /** 容器尺寸 / cols / rows 变化 */

--- a/entry/src/main/ets/pages/SshTerminal.ets
+++ b/entry/src/main/ets/pages/SshTerminal.ets
@@ -343,6 +343,12 @@ struct SshTerminal {
 
   async aboutToAppear(): Promise<void> {
     this.terminalClosing = false;
+    // ArkUI 可能复用页面实例；每次进入都必须从全新的会话输出开始。
+    this.termOutput = '';
+    this.connected = false;
+    this.connecting = true;
+    this.connectionError = '';
+    this.sessionId = -1;
     this.updateCellSize();
     this.termRows = this.calcRowsFallback();
     this.termCols = this.calcColsFallback();
@@ -413,6 +419,8 @@ struct SshTerminal {
     }
     this.loader.disconnect();
     this.sessionId = -1;
+    this.connected = false;
+    this.termOutput = '';
   }
 
   private setupKeyboardAvoidMode(): void {

--- a/entry/src/main/ets/services/FeedbackCommunityPolicy.ets
+++ b/entry/src/main/ets/services/FeedbackCommunityPolicy.ets
@@ -5,7 +5,7 @@
  */
 
 export const FEEDBACK_COMMUNITY_MANIFEST_URL: string =
-  'https://mydstiny.github.io/RemoteDeskHarmonyOS/feedback/chanlian.json';
+  'https://lijiong.online/feedback/chanlian.json';
 export const FEEDBACK_COMMUNITY_QR_MAX_AGE_MS: number = 7 * 24 * 60 * 60 * 1000;
 export const FEEDBACK_COMMUNITY_CLOCK_SKEW_MS: number = 5 * 60 * 1000;
 

--- a/entry/src/main/ets/services/FeedbackCommunityService.ets
+++ b/entry/src/main/ets/services/FeedbackCommunityService.ets
@@ -15,6 +15,19 @@ function responseCodeIsSuccess(code: number): boolean {
   return code >= 200 && code < 300;
 }
 
+function responseBytes(result: Object): ArrayBuffer {
+  if (result instanceof ArrayBuffer) {
+    return result as ArrayBuffer;
+  }
+  if (result instanceof Uint8Array) {
+    const view: Uint8Array = result as Uint8Array;
+    const copy: Uint8Array = new Uint8Array(view.byteLength);
+    copy.set(view);
+    return copy.buffer;
+  }
+  throw new Error('云端二维码响应类型无效: ' + typeof result);
+}
+
 export class FeedbackCommunityService {
   async fetchManifest(): Promise<FeedbackCommunityManifest> {
     const request: http.HttpRequest = http.createHttp();
@@ -57,10 +70,11 @@ export class FeedbackCommunityService {
       if (!responseCodeIsSuccess(response.responseCode as number)) {
         throw new Error('二维码下载失败: HTTP ' + (response.responseCode as number).toString());
       }
-      if (!(response.result instanceof ArrayBuffer) || response.result.byteLength === 0) {
+      const bytes: ArrayBuffer = responseBytes(response.result as Object);
+      if (bytes.byteLength === 0) {
         throw new Error('云端二维码内容为空');
       }
-      return response.result as ArrayBuffer;
+      return bytes;
     } finally {
       request.destroy();
     }

--- a/entry/src/main/ets/services/SshTerminalScrollPolicy.ets
+++ b/entry/src/main/ets/services/SshTerminalScrollPolicy.ets
@@ -72,7 +72,7 @@ export function terminalSparseContentGridTop(
   topInset: number,
   visibleViewportHeight: number,
   contentHeight: number,
-  sparseContentMaxHeight: number,
+  _sparseContentMaxHeight: number,
   hasScrollback: boolean
 ): number {
   const safeTopInset: number = Math.max(0, topInset);
@@ -81,8 +81,7 @@ export function terminalSparseContentGridTop(
   }
   const safeViewportHeight: number = Math.max(0, visibleViewportHeight);
   const safeContentHeight: number = Math.max(0, contentHeight);
-  const safeSparseMaxHeight: number = Math.max(0, sparseContentMaxHeight);
-  if (safeContentHeight >= safeViewportHeight || safeContentHeight > safeSparseMaxHeight) {
+  if (safeContentHeight >= safeViewportHeight) {
     return safeTopInset;
   }
   return Math.floor(safeTopInset + safeViewportHeight - safeContentHeight);
@@ -94,16 +93,14 @@ export function terminalGridTop(
   visibleViewportHeight: number,
   gridHeight: number,
   contentHeight: number,
-  sparseContentMaxHeight: number,
+  _sparseContentMaxHeight: number,
   hasScrollback: boolean
 ): number {
   const safeTopInset: number = Math.max(0, topInset);
   const safeVisibleHeight: number = Math.max(0, visibleViewportHeight);
   const safeGridHeight: number = Math.max(0, gridHeight);
   const safeContentHeight: number = Math.max(0, contentHeight);
-  const safeSparseMaxHeight: number = Math.max(0, sparseContentMaxHeight);
-  if (bottomAlignSparseContent && !hasScrollback &&
-    safeContentHeight < safeVisibleHeight && safeContentHeight <= safeSparseMaxHeight) {
+  if (bottomAlignSparseContent && !hasScrollback && safeContentHeight < safeVisibleHeight) {
     return Math.floor(safeTopInset + safeVisibleHeight - safeContentHeight);
   }
   if (safeGridHeight > safeVisibleHeight) {

--- a/entry/src/test/SshTerminalScrollPolicy.test.ets
+++ b/entry/src/test/SshTerminalScrollPolicy.test.ets
@@ -82,8 +82,9 @@ export default function sshTerminalScrollPolicyTest(): void {
       expect(terminalSparseContentGridTop(true, 122, 627, 48, 128, false)).assertEqual(701);
     });
 
-    it('should_top_align_non_sparse_command_history_before_scrollback_exists', 0, (): void => {
-      expect(terminalSparseContentGridTop(true, 122, 627, 320, 128, false)).assertEqual(122);
+    it('should_bottom_align_login_banner_before_scrollback_exists', 0, (): void => {
+      expect(terminalSparseContentGridTop(true, 122, 627, 320, 128, false)).assertEqual(429);
+      expect(terminalGridTop(true, 122, 627, 627, 320, 128, false)).assertEqual(429);
     });
 
     it('should_anchor_full_grid_bottom_when_keyboard_reduces_visible_viewport', 0, (): void => {


### PR DESCRIPTION
## What changed

- serve the feedback community QR code from the domestic Hexo endpoint and keep image saving functional
- buffer SSH shell output that arrives before the ArkTS callback is registered
- reset SSH page and renderer lifecycle state between sessions
- keep a complete mobile login banner bottom-aligned until real scrollback exists

## Root cause

The SSH reader started before the ArkTS callback could be registered, so the first session could drop its login banner. Later sessions received the full banner, which exceeded the old eight-line sparse-content threshold and switched the canvas to top alignment. Reused page/renderer state also was not fully reset.

## Validation

- device `192.168.31.156:38451`: consecutive first and second SSH connections now render consistently
- `default@OhosTestCompileArkTS`: passed
- native tests: 98 passed, 0 failed
- production `assembleHap`: passed
- Light open-source compliance gate: passed
- `git diff --check`: passed