### PR TITLE
fix(input): isolate remote IME preview text

### DIFF
--- a/entry/src/main/ets/pages/RemoteDesktop.ets
+++ b/entry/src/main/ets/pages/RemoteDesktop.ets
@@ -79,11 +79,13 @@ import {
 } from '../services/RdpSessionErrorPolicy';
 import {
   REMOTE_IME_CENTER,
+  REMOTE_IME_PREVIEW_ENABLED,
   RemoteImeSelectionAction,
   createRemoteImeDiagnostic,
   createRemoteImeShadow,
   resolveRemoteImeDelete,
   resolveRemoteImeSelection,
+  shouldAcceptRemoteImeTextChange,
   shouldRecenterRemoteImeShadow
 } from '../services/RemoteImeSessionPolicy';
 import {
@@ -3765,6 +3767,18 @@ struct RemoteDesktop {
     this.enqueueRemoteImeDelete(deletion.backwardCount, deletion.forwardCount);
   }
 
+  private handleKeyboardTextChange(value: string, previewText?: PreviewText): void {
+    const previewUnits: number = previewText ? previewText.value.length : 0;
+    if (!shouldAcceptRemoteImeTextChange(this.keyboardImeActive, previewUnits)) {
+      if (previewUnits > 0) {
+        hilog.debug(RD_DOMAIN, RD_TAG,
+          'kbd-ime-change ignored previewUnits=' + previewUnits.toString());
+      }
+      return;
+    }
+    this.keyboardText = value;
+  }
+
   private enqueueRemoteImeDelete(backwardCount: number, forwardCount: number): void {
     if (backwardCount > 0) {
       this.keyboardCommandQueue.enqueueKeyTaps(KEYCODE_DEL, backwardCount,
@@ -4993,6 +5007,7 @@ struct RemoteDesktop {
         .defaultFocus(false)
         .focusOnTouch(true)
         .enableKeyboardOnFocus(true)
+        .enablePreviewText(REMOTE_IME_PREVIEW_ENABLED)
         .selectionMenuHidden(true)
         .enterKeyType(EnterKeyType.Send)
         .onWillInsert((info: InsertValue): boolean => {
@@ -5021,8 +5036,8 @@ struct RemoteDesktop {
             this.markKeyboardClosed('ime');
           }
         })
-        .onChange((value: string) => {
-          this.keyboardText = value;
+        .onChange((value: string, previewText?: PreviewText) => {
+          this.handleKeyboardTextChange(value, previewText);
         })
         .onSubmit((enterKey: EnterKeyType, event: SubmitEvent): void => {
           hilog.info(RD_DOMAIN, RD_TAG, 'kbd-submit enterKey=' + enterKey.toString());

--- a/entry/src/main/ets/services/RemoteImeSessionPolicy.ets
+++ b/entry/src/main/ets/services/RemoteImeSessionPolicy.ets
@@ -7,6 +7,9 @@
 
 export const REMOTE_IME_CENTER: number = 2048;
 export const REMOTE_IME_EDGE_THRESHOLD: number = 256;
+// The remote editor cannot mirror HarmonyOS composing text. Keep the local
+// IME responsible for candidate selection and forward only committed text.
+export const REMOTE_IME_PREVIEW_ENABLED: boolean = false;
 
 export enum RemoteImeSelectionAction {
   IGNORE_INACTIVE = 0,
@@ -159,6 +162,10 @@ export function resolveRemoteImeDelete(
 
 export function shouldRecenterRemoteImeShadow(caret: number, textLength: number): boolean {
   return caret < REMOTE_IME_EDGE_THRESHOLD || caret > textLength - REMOTE_IME_EDGE_THRESHOLD;
+}
+
+export function shouldAcceptRemoteImeTextChange(active: boolean, previewTextLength: number): boolean {
+  return active && previewTextLength === 0;
 }
 
 export function createRemoteImeDiagnostic(

--- a/entry/src/ohosTest/ets/test/RemoteImeSessionPolicy.test.ets
+++ b/entry/src/ohosTest/ets/test/RemoteImeSessionPolicy.test.ets
@@ -4,11 +4,13 @@
 import { describe, it, expect } from '@ohos/hypium';
 import {
   REMOTE_IME_CENTER,
+  REMOTE_IME_PREVIEW_ENABLED,
   RemoteImeSelectionAction,
   createRemoteImeDiagnostic,
   createRemoteImeShadow,
   resolveRemoteImeDelete,
   resolveRemoteImeSelection,
+  shouldAcceptRemoteImeTextChange,
   shouldRecenterRemoteImeShadow,
   splitRemoteImeCaretMovement
 } from '../../../main/ets/services/RemoteImeSessionPolicy';
@@ -19,6 +21,16 @@ export default function remoteImeSessionPolicyTest(): void {
       const shadow = createRemoteImeShadow();
       expect(shadow.caret).assertEqual(REMOTE_IME_CENTER);
       expect(shadow.text.length).assertEqual(REMOTE_IME_CENTER * 2);
+    });
+
+    it('disables_preview_text_for_remote_virtual_keyboard', 0, (): void => {
+      expect(REMOTE_IME_PREVIEW_ENABLED).assertFalse();
+    });
+
+    it('does_not_rebind_shadow_while_preview_text_is_active', 0, (): void => {
+      expect(shouldAcceptRemoteImeTextChange(true, 4)).assertFalse();
+      expect(shouldAcceptRemoteImeTextChange(true, 0)).assertTrue();
+      expect(shouldAcceptRemoteImeTextChange(false, 0)).assertFalse();
     });
 
     it('ignores_expected_and_programmatic_selection', 0, (): void => {


### PR DESCRIPTION
## Summary
- disable HarmonyOS preview text for the hidden remote editor
- ignore residual composing-state changes before rebinding the shadow buffer
- add regression coverage for the shared RDP/RustDesk input policy

## Verification
- entry ohosTest ArkTS compilation passed
- default@OhosTestCompileArkTS passed
- assembleHap passed
- Light open-source compliance gate passed
- signed HAP installed and launched on 127.0.0.1:5555 and 127.0.0.1:5557

## Remaining runtime coverage
- authenticated RDP and RustDesk Chinese IME preview-text acceptance is not available in this environment