### PR TITLE
feat(rdp): add local file clipboard transfer and stabilize RustDesk endpoints

### DIFF
--- a/docs/superpowers/plans/2026-07-15-rustdesk-domain-resolution.md
+++ b/docs/superpowers/plans/2026-07-15-rustdesk-domain-resolution.md
@@ -1,0 +1,128 @@
+# RustDesk Domain Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix RustDesk FFI connections so ID/Rendezvous, Relay, direct, and file-transfer paths support DNS hostnames without changing protocol authentication or API behavior.
+
+**Architecture:** Add one focused TCP endpoint helper around `ToSocketAddrs` and a shared deadline. Replace the three direct `SocketAddr` parsing sites with the helper, while retaining protocol-specific framing and state transitions in their current modules.
+
+**Tech Stack:** Rust 2021, `std::net::ToSocketAddrs`, `TcpStream`, existing `cargo test` unit-test layout, HarmonyOS HAP/native build scripts.
+
+## Global Constraints
+
+- Work only in `C:\Users\14288\DevEcoStudioProjects\RemoteDesktop`.
+- Do not create a persistent Git worktree.
+- Do not modify API configuration semantics; blank API remains valid for ordinary connections.
+- Do not log passwords, public/private server keys, tokens, or API credentials.
+- Preserve the existing 10-second TCP connect budget and current protocol state machine.
+- Run tests before claiming completion.
+
+### Task 1: Add failing endpoint regression tests
+
+**Files:**
+- Modify: `rustdesk_ffi/src/protocol/rendezvous.rs:653-end`
+- Modify: `rustdesk_ffi/src/connector.rs:2050-end`
+
+**Interfaces:**
+- Consume: existing `RendezvousClient::connect`, `RendezvousClient::create_relay`, and `RustDeskConnector::connect_direct`.
+- Produce: failing tests that demonstrate hostname endpoints are rejected by the current implementation.
+
+- [x] **Step 1: Write tests using local listeners and hostname endpoints.**
+
+  Add tests that bind `127.0.0.1:0`, call the existing connection paths with `localhost`, and assert the connection succeeds or reaches the listener. Add an invalid `https://localhost` test that expects `InvalidInput`.
+
+- [x] **Step 2: Run the focused tests and verify the failure is the current hostname parse error.**
+
+  Run:
+
+  ```powershell
+  cargo test --manifest-path rustdesk_ffi/Cargo.toml --no-default-features hostname -- --nocapture
+  ```
+
+  Expected: failure before any protocol frame is processed because `localhost:<port>` is parsed as a `SocketAddr`.
+
+### Task 2: Implement shared DNS-capable TCP connection helper
+
+**Files:**
+- Create: `rustdesk_ffi/src/net.rs`
+- Modify: `rustdesk_ffi/src/lib.rs:23-30`
+
+**Interfaces:**
+- Consumes: host/port endpoint strings and a stage label.
+- Produces: `connect_tcp_endpoint(endpoint: &str, default_port: u16, stage: &str, timeout: Duration) -> io::Result<TcpStream>`.
+
+- [x] **Step 1: Add the helper with strict endpoint validation and `ToSocketAddrs`.**
+
+  The helper must reject empty values and URI schemes, parse a supplied port when present, resolve `(host, port)` through `ToSocketAddrs`, try each candidate until one connects or the shared deadline expires, and return errors containing `stage`, masked endpoint text, and the underlying error kind.
+
+- [x] **Step 2: Run the focused tests and verify they still fail only at unintegrated call sites.**
+
+  Run:
+
+  ```powershell
+  cargo test --manifest-path rustdesk_ffi/Cargo.toml --no-default-features net -- --nocapture
+  ```
+
+  Expected: helper unit tests pass; integration tests remain red until existing call sites use the helper.
+
+### Task 3: Integrate the helper into every RustDesk TCP endpoint
+
+**Files:**
+- Modify: `rustdesk_ffi/src/protocol/rendezvous.rs:58-80`
+- Modify: `rustdesk_ffi/src/protocol/rendezvous.rs:328-344`
+- Modify: `rustdesk_ffi/src/connector.rs:234-256`
+
+**Interfaces:**
+- Consume: `net::connect_tcp_endpoint`.
+- Produce: hostname-aware Rendezvous, Relay, direct, and file-transfer connections with stage-specific errors.
+
+- [x] **Step 1: Replace `RendezvousClient::connect` direct parsing with the helper.**
+
+  Call `connect_tcp_endpoint(&format!("{}:{}", host, port), port, "rendezvous", Duration::from_secs(10))`, or pass host and port through a helper overload that avoids double parsing. Preserve read/write timeout setup and secure handshake behavior.
+
+- [x] **Step 2: Replace `create_relay` direct parsing with the helper.**
+
+  Pass the Relay response endpoint and default port `21117`; preserve the existing relay frame write and timeout setup.
+
+- [x] **Step 3: Replace `connect_direct` direct parsing with the helper.**
+
+  Pass the configured direct host and port with stage `direct`; preserve the existing peer public-key and login protocol.
+
+- [x] **Step 4: Run the focused regression tests and verify all hostname paths are green.**
+
+  Run:
+
+  ```powershell
+  cargo test --manifest-path rustdesk_ffi/Cargo.toml --no-default-features net -- --nocapture
+  cargo test --manifest-path rustdesk_ffi/Cargo.toml --no-default-features rendezvous_ -- --nocapture
+  cargo test --manifest-path rustdesk_ffi/Cargo.toml --no-default-features relay_connect_accepts_hostname_endpoint_with_explicit_port -- --nocapture
+  cargo test --manifest-path rustdesk_ffi/Cargo.toml --no-default-features direct_connect_resolves_hostname_before_peer_handshake -- --nocapture
+  ```
+
+  Expected: all focused tests pass.
+
+### Task 4: Run full verification and update project memory
+
+**Files:**
+- Modify: `C:\Users\14288\.codex\projects\C--Users-14288\memory\CURRENT.md`
+- Modify: `C:\Users\14288\.codex\projects\C--Users-14288\memory\QUEUE.md`
+
+**Interfaces:**
+- Consume: completed code and test results.
+- Produce: evidence-backed checkpoint with exact command results and remaining real-device acceptance.
+
+- [x] **Step 1: Run the full Rust test suite.**
+
+  ```powershell
+  cargo test --manifest-path rustdesk_ffi/Cargo.toml --no-default-features --quiet
+  ```
+
+- [x] **Step 2: Run project native/ArkTS/HAP/Light gates according to `CURRENT.md`.**
+
+  Record exact exit codes and failure counts; do not claim a gate passed from partial output.
+
+- [x] **Step 3: Run `git diff --check` and inspect the final diff.**
+
+- [x] **Step 4: Update memory with completed verification and remaining real-device hostname acceptance.**
+
+- [x] **Step 5: Commit only the RustDesk fix, tests, and design/plan records.**

--- a/docs/superpowers/specs/2026-07-15-rustdesk-domain-resolution-design.md
+++ b/docs/superpowers/specs/2026-07-15-rustdesk-domain-resolution-design.md
@@ -1,0 +1,44 @@
+# RustDesk Domain Resolution Design
+
+## Goal
+
+让 RustDesk FFI 的 ID/Rendezvous、Relay、直连和文件传输连接路径可靠支持域名、IPv4 和 IPv6，同时把解析失败与 TCP 连接失败以阶段化错误返回给 ArkTS/UI。API 地址保持可选，不参与普通远程连接。
+
+## Root cause
+
+当前 `rustdesk_ffi` 在多个位置把 `host:port` 直接解析为 `SocketAddr`。Rust 的 `SocketAddr` 解析只接受字面量地址，不执行 DNS 解析，因此 `hbbs.example.com` 和 `hbbr.example.com` 会在 TCP 建立前失败。`RendezvousConnecting` 的状态来自 ID 服务器连接阶段；Relay 解析也存在相同缺陷。
+
+## Design
+
+新增一个小型网络连接模块，使用 `ToSocketAddrs` 将 host/port 解析为一个或多个候选 `SocketAddr`，在共享 deadline 内逐个调用 `TcpStream::connect_timeout`。模块负责：
+
+- 接受独立的 host + port，以及 Relay 响应中可能携带端口的 endpoint 字符串；
+- 拒绝 `http://`、`https://`、路径和空 endpoint，并返回 `InvalidInput`；
+- 支持域名、IPv4、IPv6 和 IPv6 bracket 形式；
+- 尝试所有 DNS 候选地址，返回包含阶段、host、port 和底层错误的诊断；
+- 不记录密码、服务器 Key 或 API 凭据。
+
+现有 RendezvousClient 的 ID 连接、Relay 连接和 Connector 直连全部调用该模块。协议握手、Key、密码、API 字段和状态机顺序不改变。
+
+## Error handling
+
+错误阶段至少区分 `rendezvous resolve/connect`、`relay resolve/connect` 和 `direct resolve/connect`。FFI 继续通过 `rustdesk_last_error` 暴露完整错误，UI 可以据此提示地址格式、端口不可达或网络路由问题。
+
+## Tests
+
+回归测试先验证现有实现对 `localhost` 的失败，再验证修复后：
+
+- Rendezvous 使用域名连接本地 listener；
+- Relay endpoint 使用域名和显式端口连接本地 listener；
+- direct endpoint 使用域名连接本地 listener；
+- 无效 URL 形式被拒绝；
+- IPv4/IPv6 endpoint 解析保持可用；
+- 多候选地址在首个候选失败后继续尝试。
+
+## Acceptance
+
+- `cargo test --manifest-path rustdesk_ffi/Cargo.toml --no-default-features` 通过（88/88）；
+- 本机默认 `opus-audio` host 链接仍受缺少 `-lopus` 影响，OHOS HAP 构建已使用项目实际 native 链路通过；
+- 受影响 HarmonyOS native 测试通过；
+- `assembleHap`、`default@OhosTestCompileArkTS` 和 Light 合规门通过；
+- 真机使用 `hbbs`/`hbbr` 域名完成首次连接、重连和 Relay 连接验证仍待设备环境执行。

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -38,6 +38,8 @@ set(PROTOCOL_SOURCES
     rdp/rdp_gl_upload_gate.cpp
     rdp/rdp_graphics_lifecycle.cpp
     rdp/rdp_frame_pump.cpp
+    rdp/rdp_file_clipboard_bridge.cpp
+    rdp/rdp_file_clipboard_offer.cpp
     rustdesk/rustdesk_bridge.cpp
 )
 
@@ -151,6 +153,7 @@ if(RDP_BUILD_TESTS)
         test/rdp_performance_policy_test.cpp
         test/transfer_runtime_status_test.cpp
         test/rdp_input_queue_test.cpp
+        test/rdp_file_clipboard_offer_test.cpp
         test/gl_surface_lifecycle_policy_test.cpp
         test/native_image_context_policy_test.cpp
         test/decoder_recovery_policy_test.cpp
@@ -163,6 +166,7 @@ if(RDP_BUILD_TESTS)
         rdp/rdp_frame_scheduler.cpp
         rdp/rdp_gl_upload_gate.cpp
         rdp/rdp_graphics_lifecycle.cpp
+        rdp/rdp_file_clipboard_offer.cpp
         audio/audio_queue_policy.cpp
         audio/audio_activity_state.cpp
         video/video_activity_state.cpp

--- a/entry/src/main/cpp/extensions/extension_loader_napi.cpp
+++ b/entry/src/main/cpp/extensions/extension_loader_napi.cpp
@@ -1681,6 +1681,58 @@ napi_value NapiSendClipboard(napi_env env, napi_callback_info info) {
     return undefined;
 }
 
+/**
+ * NAPI: setSessionClipboardFiles(sessionId: number, paths: string[]): boolean
+ * paths 必须是已复制到应用沙箱中的稳定绝对路径。
+ */
+napi_value NapiSetSessionClipboardFiles(napi_env env, napi_callback_info info) {
+    size_t argc = 2;
+    napi_value args[2];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    int32_t sessionId = 0;
+    bool accepted = false;
+    bool isArray = false;
+    if (argc == 2 && napi_get_value_int32(env, args[0], &sessionId) == napi_ok &&
+        napi_is_array(env, args[1], &isArray) == napi_ok && isArray) {
+        uint32_t length = 0;
+        if (napi_get_array_length(env, args[1], &length) == napi_ok &&
+            length > 0 && length <= 15) {
+            std::vector<std::string> paths;
+            paths.reserve(length);
+            bool valid = true;
+            for (uint32_t index = 0; index < length; ++index) {
+                napi_value item;
+                napi_valuetype type = napi_undefined;
+                size_t byteLength = 0;
+                if (napi_get_element(env, args[1], index, &item) != napi_ok ||
+                    napi_typeof(env, item, &type) != napi_ok || type != napi_string ||
+                    napi_get_value_string_utf8(env, item, nullptr, 0, &byteLength) != napi_ok ||
+                    byteLength == 0 || byteLength > 4096) {
+                    valid = false;
+                    break;
+                }
+                std::vector<char> buffer(byteLength + 1, '\0');
+                size_t written = 0;
+                if (napi_get_value_string_utf8(env, item, buffer.data(), buffer.size(),
+                                               &written) != napi_ok || written != byteLength) {
+                    valid = false;
+                    break;
+                }
+                paths.emplace_back(buffer.data(), written);
+            }
+            auto it = g_sessions.find(sessionId);
+            if (valid && it != g_sessions.end() && it->second->adapter) {
+                accepted = it->second->adapter->setClipboardFiles(paths);
+            }
+        }
+    }
+
+    napi_value result;
+    napi_get_boolean(env, accepted, &result);
+    return result;
+}
+
 napi_value NapiGetSessionClipboardText(napi_env env, napi_callback_info info) {
     size_t argc = 1;
     napi_value args[1];
@@ -2433,6 +2485,9 @@ napi_value ExtensionLoaderNapi::Init(napi_env env, napi_value exports) {
     napi_create_function(env, "sendClipboard", NAPI_AUTO_LENGTH,
                          NapiSendClipboard, nullptr, &fn);
     napi_set_named_property(env, exports, "sendClipboard", fn);
+    napi_create_function(env, "setSessionClipboardFiles", NAPI_AUTO_LENGTH,
+                         NapiSetSessionClipboardFiles, nullptr, &fn);
+    napi_set_named_property(env, exports, "setSessionClipboardFiles", fn);
     napi_create_function(env, "getSessionClipboardText", NAPI_AUTO_LENGTH,
                          NapiGetSessionClipboardText, nullptr, &fn);
     napi_set_named_property(env, exports, "getSessionClipboardText", fn);

--- a/entry/src/main/cpp/extensions/protocol_adapter.h
+++ b/entry/src/main/cpp/extensions/protocol_adapter.h
@@ -328,6 +328,9 @@ public:
     /** 设置剪贴板文本（从本地同步到远程） */
     virtual void setClipboardText(const std::string& text) {}
 
+    /** 设置本地文件剪贴板（稳定的应用沙箱绝对路径） */
+    virtual bool setClipboardFiles(const std::vector<std::string>& /*paths*/) { return false; }
+
     /** 获取剪贴板文本（从远程同步到本地） */
     virtual std::string getClipboardText() { return ""; }
     virtual bool isClipboardReceiveReady() { return false; }

--- a/entry/src/main/cpp/rdp/freerdp_adapter.cpp
+++ b/entry/src/main/cpp/rdp/freerdp_adapter.cpp
@@ -17,6 +17,7 @@
 #include "rdp_background_frame_cache.h"
 #include "rdp_certificate_policy.h"
 #include "rdp_frame_pump.h"
+#include "rdp_file_clipboard_bridge.h"
 #include "rdp_graphics_lifecycle.h"
 #include "rdp_keymap.h"
 #include "rdp_performance_policy.h"
@@ -527,6 +528,7 @@ struct FreeRdpAdapter::Impl {
     ConnectionStateCallback stateCallback;
     std::string             clipboardText;
     CliprdrClientContext*   cliprdr = nullptr;
+    std::unique_ptr<RdpFileClipboardBridge> fileClipboard;
     pthread_t               eventThread = 0;
     pthread_t               connectThread = 0;
     pthread_t               driveThread = 0;
@@ -1081,13 +1083,17 @@ void FreeRdpAdapter::cbChannelConnected(void* context, const ChannelConnectedEve
     if (std::strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0 && e->pInterface) {
         auto* owner = reinterpret_cast<FreeRdpContext*>(rdpContext)->adapter;
         auto* cliprdr = reinterpret_cast<CliprdrClientContext*>(e->pInterface);
-        if (owner && owner->impl_) {
+        if (owner && owner->impl_ && owner->impl_->fileClipboard &&
+            owner->impl_->fileClipboard->attach(cliprdr)) {
             owner->impl_->cliprdr = cliprdr;
-            cliprdr->custom = owner;
+            cliprdr->ServerCapabilities = cbCliprdrServerCapabilities;
             cliprdr->MonitorReady = cbCliprdrMonitorReady;
             cliprdr->ServerFormatList = cbCliprdrServerFormatList;
             cliprdr->ServerFormatDataRequest = cbCliprdrServerFormatDataRequest;
             cliprdr->ServerFormatDataResponse = cbCliprdrServerFormatDataResponse;
+        } else {
+            OH_LOG_WARN(LOG_APP,
+                        "[RDP] file clipboard bridge unavailable; clipboard disabled for this session");
         }
     }
 #if defined(CHANNEL_RDPGFX_CLIENT)
@@ -1144,19 +1150,47 @@ void FreeRdpAdapter::cbChannelConnected(void* context, const ChannelConnectedEve
 
 UINT FreeRdpAdapter::cbCliprdrMonitorReady(CliprdrClientContext* context,
                                            const CLIPRDR_MONITOR_READY*) {
-    if (!context || !context->ClientFormatList) return ERROR_INVALID_PARAMETER;
-    CLIPRDR_FORMAT format {};
-    format.formatId = CF_UNICODETEXT;
-    CLIPRDR_FORMAT_LIST list {};
-    list.common.msgType = CB_FORMAT_LIST;
-    list.numFormats = 1;
-    list.formats = &format;
-    return context->ClientFormatList(context, &list);
+    auto* owner = context ? static_cast<FreeRdpAdapter*>(
+        RdpFileClipboardBridge::ownerFromContext(context)) : nullptr;
+    if (!owner || !owner->impl_ || !owner->impl_->fileClipboard) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    const UINT capabilityResult = owner->impl_->fileClipboard->sendClientCapabilities();
+    if (capabilityResult != CHANNEL_RC_OK) {
+        return capabilityResult;
+    }
+    return owner->impl_->fileClipboard->sendCurrentFormatList(true);
+}
+
+UINT FreeRdpAdapter::cbCliprdrServerCapabilities(
+    CliprdrClientContext* context, const CLIPRDR_CAPABILITIES* capabilities) {
+    auto* owner = context ? static_cast<FreeRdpAdapter*>(
+        RdpFileClipboardBridge::ownerFromContext(context)) : nullptr;
+    if (!owner || !owner->impl_ || !owner->impl_->fileClipboard) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    return owner->impl_->fileClipboard->updateServerCapabilities(capabilities);
 }
 
 UINT FreeRdpAdapter::cbCliprdrServerFormatList(CliprdrClientContext* context,
                                                const CLIPRDR_FORMAT_LIST* list) {
-    if (!context || !list || !context->ClientFormatDataRequest) return ERROR_INVALID_PARAMETER;
+    auto* owner = context ? static_cast<FreeRdpAdapter*>(
+        RdpFileClipboardBridge::ownerFromContext(context)) : nullptr;
+    if (!owner || !owner->impl_ || !owner->impl_->fileClipboard || !list ||
+        !context->ClientFormatListResponse) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    const UINT notifyResult = owner->impl_->fileClipboard->notifyServerFormatList();
+    if (notifyResult != CHANNEL_RC_OK) {
+        return notifyResult;
+    }
+    CLIPRDR_FORMAT_LIST_RESPONSE response {};
+    response.common.msgType = CB_FORMAT_LIST_RESPONSE;
+    response.common.msgFlags = CB_RESPONSE_OK;
+    const UINT responseResult = context->ClientFormatListResponse(context, &response);
+    if (responseResult != CHANNEL_RC_OK || !context->ClientFormatDataRequest) {
+        return responseResult;
+    }
     for (UINT32 i = 0; i < list->numFormats; ++i) {
         if (list->formats[i].formatId == CF_UNICODETEXT) {
             CLIPRDR_FORMAT_DATA_REQUEST request {};
@@ -1170,9 +1204,18 @@ UINT FreeRdpAdapter::cbCliprdrServerFormatList(CliprdrClientContext* context,
 
 UINT FreeRdpAdapter::cbCliprdrServerFormatDataRequest(CliprdrClientContext* context,
                                                       const CLIPRDR_FORMAT_DATA_REQUEST* request) {
-    auto* owner = context ? static_cast<FreeRdpAdapter*>(context->custom) : nullptr;
-    if (!owner || !owner->impl_ || !context->ClientFormatDataResponse || !request ||
-        request->requestedFormatId != CF_UNICODETEXT) return ERROR_INVALID_PARAMETER;
+    auto* owner = context ? static_cast<FreeRdpAdapter*>(
+        RdpFileClipboardBridge::ownerFromContext(context)) : nullptr;
+    if (!owner || !owner->impl_ || !context->ClientFormatDataResponse || !request) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    if (owner->impl_->fileClipboard &&
+        owner->impl_->fileClipboard->isFileFormat(request->requestedFormatId)) {
+        return owner->impl_->fileClipboard->respondToFileFormatRequest(request);
+    }
+    if (request->requestedFormatId != CF_UNICODETEXT) {
+        return ERROR_INVALID_PARAMETER;
+    }
     std::vector<uint16_t> wide = utf8ToUtf16(owner->impl_->clipboardText);
     wide.push_back(0);
     CLIPRDR_FORMAT_DATA_RESPONSE response {};
@@ -1185,7 +1228,8 @@ UINT FreeRdpAdapter::cbCliprdrServerFormatDataRequest(CliprdrClientContext* cont
 
 UINT FreeRdpAdapter::cbCliprdrServerFormatDataResponse(CliprdrClientContext* context,
                                                        const CLIPRDR_FORMAT_DATA_RESPONSE* response) {
-    auto* owner = context ? static_cast<FreeRdpAdapter*>(context->custom) : nullptr;
+    auto* owner = context ? static_cast<FreeRdpAdapter*>(
+        RdpFileClipboardBridge::ownerFromContext(context)) : nullptr;
     if (!owner || !owner->impl_ || !response || !response->requestedFormatData) return ERROR_INVALID_PARAMETER;
     const auto* data = reinterpret_cast<const uint16_t*>(response->requestedFormatData);
     const size_t count = response->common.dataLen / sizeof(uint16_t);
@@ -1212,6 +1256,16 @@ void FreeRdpAdapter::cbChannelDisconnected(void* context, const ChannelDisconnec
     }
     OH_LOG_INFO(LOG_APP, "[RDP] channel disconnected: %{public}s interface=%{public}p",
                 e->name, e->pInterface);
+    if (std::strcmp(e->name, CLIPRDR_SVC_CHANNEL_NAME) == 0) {
+        auto* freeRdpContext = reinterpret_cast<FreeRdpContext*>(rdpContext);
+        auto* owner = freeRdpContext ? freeRdpContext->adapter : nullptr;
+        if (owner && owner->impl_) {
+            if (owner->impl_->fileClipboard) {
+                owner->impl_->fileClipboard->detach();
+            }
+            owner->impl_->cliprdr = nullptr;
+        }
+    }
 #if defined(CHANNEL_RDPGFX_CLIENT)
     if (std::strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0) {
         auto* freeRdpContext = reinterpret_cast<FreeRdpContext*>(rdpContext);
@@ -1772,6 +1826,9 @@ void FreeRdpAdapter::cleanupInstance() {
     RendererNapi::InvalidateActivePresentation();
     impl_->framePump.invalidatePending();
     impl_->stopSessionWorkers();
+    if (impl_->fileClipboard) {
+        impl_->fileClipboard->detach();
+    }
     freerdp* doomedInstance = nullptr;
     {
         std::lock_guard<std::mutex> lock(impl_->instanceMutex);
@@ -1796,6 +1853,7 @@ void FreeRdpAdapter::cleanupInstance() {
 
 FreeRdpAdapter::FreeRdpAdapter() : impl_(std::make_unique<Impl>()) {
     ensureFreeRdpStaticAddinProvider();
+    impl_->fileClipboard = std::make_unique<RdpFileClipboardBridge>(this);
     OH_LOG_INFO(LOG_APP, "[RDP] FreeRdpAdapter created (FreeRDP 3.x)");
 }
 
@@ -1964,6 +2022,10 @@ void FreeRdpAdapter::connectThreadFunc() {
     freerdp_settings_set_bool(s, FreeRDP_DeviceRedirection,
                               (cfg.rdAudioEnabled || driveEnabled) ? TRUE : FALSE);
     freerdp_settings_set_bool(s, FreeRDP_RedirectClipboard, cfg.rdClipboardEnabled ? TRUE : FALSE);
+    const UINT32 clipboardFeatureMask = cfg.rdClipboardEnabled ?
+        (CLIPRDR_FLAG_LOCAL_TO_REMOTE | CLIPRDR_FLAG_REMOTE_TO_LOCAL |
+         CLIPRDR_FLAG_LOCAL_TO_REMOTE_FILES) : 0;
+    freerdp_settings_set_uint32(s, FreeRDP_ClipboardFeatureMask, clipboardFeatureMask);
     const std::string driveName = sanitizeRdpDriveName(cfg.rdDriveName);
     // 不在连接握手前注册自定义 drive。rdpdr 通道加载后由异步线程 post-connected 挂载。
     freerdp_settings_set_bool(s, FreeRDP_RedirectDrives, FALSE);
@@ -2480,15 +2542,19 @@ void FreeRdpAdapter::setConnectionStateCallback(ConnectionStateCallback cb) { im
 
 void FreeRdpAdapter::setClipboardText(const std::string& t) {
     impl_->clipboardText = t;
-    if (impl_->cliprdr && impl_->cliprdr->ClientFormatList) {
-        CLIPRDR_FORMAT format {};
-        format.formatId = CF_UNICODETEXT;
-        CLIPRDR_FORMAT_LIST list {};
-        list.common.msgType = CB_FORMAT_LIST;
-        list.numFormats = 1;
-        list.formats = &format;
-        impl_->cliprdr->ClientFormatList(impl_->cliprdr, &list);
+    if (impl_->fileClipboard) {
+        impl_->fileClipboard->clearLocalFiles();
+        if (impl_->cliprdr) {
+            impl_->fileClipboard->sendCurrentFormatList(true);
+        }
     }
+}
+bool FreeRdpAdapter::setClipboardFiles(const std::vector<std::string>& paths) {
+    if (!impl_->fileClipboard || !impl_->cliprdr) {
+        return false;
+    }
+    return impl_->fileClipboard->publishLocalFiles(paths) ==
+        RdpFileClipboardOfferResult::Ready;
 }
 void FreeRdpAdapter::sendClipboardData(const uint8_t* data, uint32_t len) {
     if (data == nullptr || len == 0) return;
@@ -2786,6 +2852,7 @@ void FreeRdpAdapter::setAudioCallback(AudioDataCallback cb) { impl_->audioCallba
 void FreeRdpAdapter::setConnectionStateCallback(ConnectionStateCallback cb) { impl_->stateCallback = std::move(cb); }
 
 void FreeRdpAdapter::setClipboardText(const std::string& t) { impl_->clipboardText = t; }
+bool FreeRdpAdapter::setClipboardFiles(const std::vector<std::string>&) { return false; }
 void FreeRdpAdapter::sendClipboardData(const uint8_t* data, uint32_t len) {
     if (data == nullptr || len == 0) return;
     setClipboardText(std::string(reinterpret_cast<const char*>(data), len));

--- a/entry/src/main/cpp/rdp/freerdp_adapter.h
+++ b/entry/src/main/cpp/rdp/freerdp_adapter.h
@@ -73,6 +73,7 @@ public:
 
     // ---- 扩展功能 ----
     void        setClipboardText(const std::string& text) override;
+    bool        setClipboardFiles(const std::vector<std::string>& paths) override;
     void        sendClipboardData(const uint8_t* data, uint32_t len) override;
     std::string getClipboardText() override;
     bool        isClipboardReceiveReady() override;
@@ -130,6 +131,8 @@ private:
     static void cbChannelConnected(void* context, const ChannelConnectedEventArgs* e);
     static void cbChannelDisconnected(void* context, const ChannelDisconnectedEventArgs* e);
     static UINT cbCliprdrMonitorReady(CliprdrClientContext* context, const CLIPRDR_MONITOR_READY* ready);
+    static UINT cbCliprdrServerCapabilities(CliprdrClientContext* context,
+                                           const CLIPRDR_CAPABILITIES* capabilities);
     static UINT cbCliprdrServerFormatList(CliprdrClientContext* context, const CLIPRDR_FORMAT_LIST* list);
     static UINT cbCliprdrServerFormatDataRequest(CliprdrClientContext* context,
                                                 const CLIPRDR_FORMAT_DATA_REQUEST* request);

--- a/entry/src/main/cpp/rdp/rdp_file_clipboard_bridge.cpp
+++ b/entry/src/main/cpp/rdp/rdp_file_clipboard_bridge.cpp
@@ -1,0 +1,268 @@
+#include "rdp_file_clipboard_bridge.h"
+
+#ifdef USE_REAL_FREERDP
+
+#include <freerdp/settings_types.h>
+#include <freerdp/utils/cliprdr_utils.h>
+#include <winpr/shell.h>
+
+#include <cstdlib>
+
+namespace {
+
+constexpr char kMimeUriList[] = "text/uri-list";
+constexpr char kFileGroupDescriptorW[] = "FileGroupDescriptorW";
+
+} // namespace
+
+RdpFileClipboardBridge::RdpFileClipboardBridge(void* owner) : owner_(owner) {
+    clipboard_ = ClipboardCreate();
+    fileContext_ = cliprdr_file_context_new(owner_);
+    if (!clipboard_ || !fileContext_ || !initializeClipboardFormats()) {
+        if (fileContext_) {
+            cliprdr_file_context_free(fileContext_);
+            fileContext_ = nullptr;
+        }
+        if (clipboard_) {
+            ClipboardDestroy(clipboard_);
+            clipboard_ = nullptr;
+        }
+    }
+}
+
+RdpFileClipboardBridge::~RdpFileClipboardBridge() {
+    detach();
+    if (fileContext_) {
+        cliprdr_file_context_free(fileContext_);
+    }
+    if (clipboard_) {
+        ClipboardDestroy(clipboard_);
+    }
+}
+
+bool RdpFileClipboardBridge::initializeClipboardFormats() {
+    uriListFormatId_ = ClipboardRegisterFormat(clipboard_, kMimeUriList);
+    fileDescriptorFormatId_ = ClipboardRegisterFormat(clipboard_, kFileGroupDescriptorW);
+    return uriListFormatId_ != 0 && fileDescriptorFormatId_ != 0 &&
+           cliprdr_file_context_set_locally_available(fileContext_, TRUE) == TRUE;
+}
+
+bool RdpFileClipboardBridge::attach(CliprdrClientContext* channel) {
+    if (!channel || !available()) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (channel_ == channel) {
+        return true;
+    }
+    if (channel_) {
+        cliprdr_file_context_uninit(fileContext_, channel_);
+        channel_->custom = nullptr;
+    }
+    channel_ = channel;
+    if (cliprdr_file_context_init(fileContext_, channel_) != TRUE) {
+        channel_->custom = nullptr;
+        channel_ = nullptr;
+        return false;
+    }
+    cliprdr_file_context_remote_set_flags(fileContext_, 0);
+    return true;
+}
+
+void RdpFileClipboardBridge::detach() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    offer_.clear();
+    if (fileContext_) {
+        cliprdr_file_context_clear(fileContext_);
+    }
+    if (clipboard_) {
+        ClipboardEmpty(clipboard_);
+    }
+    if (channel_) {
+        cliprdr_file_context_uninit(fileContext_, channel_);
+        channel_->custom = nullptr;
+        channel_ = nullptr;
+    }
+}
+
+bool RdpFileClipboardBridge::available() const {
+    return clipboard_ && fileContext_ && uriListFormatId_ != 0 &&
+           fileDescriptorFormatId_ != 0;
+}
+
+RdpFileClipboardOfferResult RdpFileClipboardBridge::publishLocalFiles(
+    const std::vector<std::string>& paths) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto result = offer_.replace(paths);
+    if (result != RdpFileClipboardOfferResult::Ready) {
+        return result;
+    }
+    if (!channel_) {
+        offer_.clear();
+        return RdpFileClipboardOfferResult::InvalidPath;
+    }
+    const auto snapshot = offer_.snapshot();
+    ClipboardEmpty(clipboard_);
+    if (ClipboardSetData(clipboard_, uriListFormatId_, snapshot.uriList.data(),
+                         static_cast<UINT32>(snapshot.uriList.size())) != TRUE ||
+        cliprdr_file_context_update_client_data(fileContext_, snapshot.uriList.data(),
+                                                snapshot.uriList.size()) != TRUE) {
+        offer_.clear();
+        cliprdr_file_context_clear(fileContext_);
+        ClipboardEmpty(clipboard_);
+        return RdpFileClipboardOfferResult::InvalidPath;
+    }
+    if (sendCurrentFormatListLocked(false) != CHANNEL_RC_OK) {
+        offer_.clear();
+        cliprdr_file_context_clear(fileContext_);
+        ClipboardEmpty(clipboard_);
+        return RdpFileClipboardOfferResult::InvalidPath;
+    }
+    return RdpFileClipboardOfferResult::Ready;
+}
+
+void RdpFileClipboardBridge::clearLocalFiles() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    offer_.clear();
+    if (fileContext_) {
+        cliprdr_file_context_clear(fileContext_);
+    }
+    if (clipboard_) {
+        ClipboardEmpty(clipboard_);
+    }
+}
+
+UINT RdpFileClipboardBridge::updateServerCapabilities(
+    const CLIPRDR_CAPABILITIES* capabilities) {
+    if (!capabilities || !capabilities->capabilitySets || !available()) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    UINT32 flags = 0;
+    const BYTE* cursor = reinterpret_cast<const BYTE*>(capabilities->capabilitySets);
+    for (UINT32 index = 0; index < capabilities->cCapabilitiesSets; ++index) {
+        const auto* capability = reinterpret_cast<const CLIPRDR_CAPABILITY_SET*>(cursor);
+        if (capability->capabilitySetLength < sizeof(CLIPRDR_CAPABILITY_SET)) {
+            return ERROR_INVALID_DATA;
+        }
+        if (capability->capabilitySetType == CB_CAPSTYPE_GENERAL &&
+            capability->capabilitySetLength >= sizeof(CLIPRDR_GENERAL_CAPABILITY_SET)) {
+            const auto* general =
+                reinterpret_cast<const CLIPRDR_GENERAL_CAPABILITY_SET*>(capability);
+            flags = general->generalFlags;
+        }
+        cursor += capability->capabilitySetLength;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    return cliprdr_file_context_remote_set_flags(fileContext_, flags) == TRUE ?
+        CHANNEL_RC_OK : ERROR_INTERNAL_ERROR;
+}
+
+UINT RdpFileClipboardBridge::sendClientCapabilities() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!channel_ || !channel_->ClientCapabilities) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    CLIPRDR_GENERAL_CAPABILITY_SET general {
+        CB_CAPSTYPE_GENERAL,
+        sizeof(CLIPRDR_GENERAL_CAPABILITY_SET),
+        CB_CAPS_VERSION_2,
+        CB_USE_LONG_FORMAT_NAMES | cliprdr_file_context_current_flags(fileContext_)
+    };
+    CLIPRDR_CAPABILITIES capabilities {};
+    capabilities.common.msgType = CB_CLIP_CAPS;
+    capabilities.cCapabilitiesSets = 1;
+    capabilities.capabilitySets =
+        reinterpret_cast<CLIPRDR_CAPABILITY_SET*>(&general);
+    return channel_->ClientCapabilities(channel_, &capabilities);
+}
+
+UINT RdpFileClipboardBridge::notifyServerFormatList() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!channel_) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    return cliprdr_file_context_notify_new_server_format_list(fileContext_);
+}
+
+UINT RdpFileClipboardBridge::sendCurrentFormatList(bool includeText) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return sendCurrentFormatListLocked(includeText);
+}
+
+UINT RdpFileClipboardBridge::sendCurrentFormatListLocked(bool includeText) {
+    if (!channel_ || !channel_->ClientFormatList) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    std::vector<CLIPRDR_FORMAT> formats;
+    if (includeText) {
+        formats.push_back({CF_UNICODETEXT, nullptr});
+    }
+    const auto snapshot = offer_.snapshot();
+    const bool fileStreamingNegotiated =
+        (cliprdr_file_context_current_flags(fileContext_) & CB_STREAM_FILECLIP_ENABLED) != 0;
+    if (snapshot.ready() && fileStreamingNegotiated) {
+        formats.push_back({fileDescriptorFormatId_, const_cast<char*>(kFileGroupDescriptorW)});
+    }
+    if (formats.empty()) {
+        return ERROR_INVALID_DATA;
+    }
+    const UINT notifyResult = cliprdr_file_context_notify_new_client_format_list(fileContext_);
+    if (notifyResult != CHANNEL_RC_OK) {
+        return notifyResult;
+    }
+    CLIPRDR_FORMAT_LIST list {};
+    list.common.msgType = CB_FORMAT_LIST;
+    list.numFormats = static_cast<UINT32>(formats.size());
+    list.formats = formats.data();
+    return channel_->ClientFormatList(channel_, &list);
+}
+
+bool RdpFileClipboardBridge::isFileFormat(UINT32 formatId) const {
+    return formatId != 0 && formatId == fileDescriptorFormatId_;
+}
+
+UINT RdpFileClipboardBridge::respondToFileFormatRequest(
+    const CLIPRDR_FORMAT_DATA_REQUEST* request) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!request || !channel_ || !channel_->ClientFormatDataResponse ||
+        !isFileFormat(request->requestedFormatId) || !offer_.snapshot().ready()) {
+        return ERROR_INVALID_PARAMETER;
+    }
+    UINT32 descriptorBytes = 0;
+    auto* descriptors = static_cast<BYTE*>(
+        ClipboardGetData(clipboard_, fileDescriptorFormatId_, &descriptorBytes));
+    if (!descriptors || descriptorBytes == 0 ||
+        descriptorBytes % sizeof(FILEDESCRIPTORW) != 0) {
+        std::free(descriptors);
+        return ERROR_INVALID_DATA;
+    }
+    BYTE* packed = nullptr;
+    UINT32 packedSize = 0;
+    const UINT serializeResult = cliprdr_serialize_file_list_ex(
+        cliprdr_file_context_remote_get_flags(fileContext_),
+        reinterpret_cast<const FILEDESCRIPTORW*>(descriptors),
+        descriptorBytes / sizeof(FILEDESCRIPTORW), &packed, &packedSize);
+    std::free(descriptors);
+    if (serializeResult != CHANNEL_RC_OK || !packed || packedSize == 0) {
+        std::free(packed);
+        return serializeResult == CHANNEL_RC_OK ? ERROR_INVALID_DATA : serializeResult;
+    }
+    CLIPRDR_FORMAT_DATA_RESPONSE response {};
+    response.common.msgType = CB_FORMAT_DATA_RESPONSE;
+    response.common.msgFlags = CB_RESPONSE_OK;
+    response.common.dataLen = packedSize;
+    response.requestedFormatData = packed;
+    const UINT result = channel_->ClientFormatDataResponse(channel_, &response);
+    std::free(packed);
+    return result;
+}
+
+void* RdpFileClipboardBridge::ownerFromContext(CliprdrClientContext* context) {
+    if (!context || !context->custom) {
+        return nullptr;
+    }
+    return cliprdr_file_context_get_context(
+        static_cast<CliprdrFileContext*>(context->custom));
+}
+
+#endif // USE_REAL_FREERDP

--- a/entry/src/main/cpp/rdp/rdp_file_clipboard_bridge.h
+++ b/entry/src/main/cpp/rdp/rdp_file_clipboard_bridge.h
@@ -1,0 +1,55 @@
+#ifndef RDP_FILE_CLIPBOARD_BRIDGE_H
+#define RDP_FILE_CLIPBOARD_BRIDGE_H
+
+#include "rdp_file_clipboard_offer.h"
+
+#ifdef USE_REAL_FREERDP
+
+#include <freerdp/client/client_cliprdr_file.h>
+#include <freerdp/client/cliprdr.h>
+#include <winpr/clipboard.h>
+
+#include <mutex>
+#include <vector>
+
+class RdpFileClipboardBridge {
+public:
+    explicit RdpFileClipboardBridge(void* owner);
+    ~RdpFileClipboardBridge();
+
+    RdpFileClipboardBridge(const RdpFileClipboardBridge&) = delete;
+    RdpFileClipboardBridge& operator=(const RdpFileClipboardBridge&) = delete;
+
+    bool attach(CliprdrClientContext* channel);
+    void detach();
+    bool available() const;
+
+    RdpFileClipboardOfferResult publishLocalFiles(const std::vector<std::string>& paths);
+    void clearLocalFiles();
+
+    UINT updateServerCapabilities(const CLIPRDR_CAPABILITIES* capabilities);
+    UINT notifyServerFormatList();
+    UINT sendClientCapabilities();
+    UINT sendCurrentFormatList(bool includeText);
+    bool isFileFormat(UINT32 formatId) const;
+    UINT respondToFileFormatRequest(const CLIPRDR_FORMAT_DATA_REQUEST* request);
+
+    static void* ownerFromContext(CliprdrClientContext* context);
+
+private:
+    bool initializeClipboardFormats();
+    UINT sendCurrentFormatListLocked(bool includeText);
+
+    void* owner_ = nullptr;
+    mutable std::mutex mutex_;
+    wClipboard* clipboard_ = nullptr;
+    CliprdrFileContext* fileContext_ = nullptr;
+    CliprdrClientContext* channel_ = nullptr;
+    UINT32 uriListFormatId_ = 0;
+    UINT32 fileDescriptorFormatId_ = 0;
+    RdpFileClipboardOffer offer_;
+};
+
+#endif // USE_REAL_FREERDP
+
+#endif // RDP_FILE_CLIPBOARD_BRIDGE_H

--- a/entry/src/main/cpp/rdp/rdp_file_clipboard_offer.cpp
+++ b/entry/src/main/cpp/rdp/rdp_file_clipboard_offer.cpp
@@ -1,0 +1,68 @@
+#include "rdp_file_clipboard_offer.h"
+
+#include <limits>
+
+bool RdpFileClipboardOffer::isStableAbsolutePath(const std::string& path) {
+    if (path.empty() || path.front() != '/') {
+        return false;
+    }
+    return path.find('\0') == std::string::npos &&
+           path.find('\r') == std::string::npos &&
+           path.find('\n') == std::string::npos;
+}
+
+std::string RdpFileClipboardOffer::buildUriList(const std::vector<std::string>& paths) {
+    std::string result;
+    for (const auto& path : paths) {
+        result.append("file://");
+        result.append(path);
+        result.append("\r\n");
+    }
+    return result;
+}
+
+void RdpFileClipboardOffer::invalidateLocked() {
+    if (generation_ == std::numeric_limits<uint64_t>::max()) {
+        generation_ = 1;
+    } else {
+        ++generation_;
+    }
+    paths_.clear();
+    uriList_.clear();
+}
+
+RdpFileClipboardOfferResult RdpFileClipboardOffer::replace(
+    const std::vector<std::string>& paths) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    invalidateLocked();
+    if (paths.empty()) {
+        return RdpFileClipboardOfferResult::Empty;
+    }
+    if (paths.size() > kMaxFilesPerOffer) {
+        return RdpFileClipboardOfferResult::TooManyFiles;
+    }
+    for (const auto& path : paths) {
+        if (!isStableAbsolutePath(path)) {
+            return RdpFileClipboardOfferResult::InvalidPath;
+        }
+    }
+    paths_ = paths;
+    uriList_ = buildUriList(paths_);
+    return RdpFileClipboardOfferResult::Ready;
+}
+
+void RdpFileClipboardOffer::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    invalidateLocked();
+}
+
+RdpFileClipboardOfferSnapshot RdpFileClipboardOffer::snapshot() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return {generation_, paths_, uriList_};
+}
+
+bool RdpFileClipboardOffer::isCurrent(uint64_t generation) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return generation != 0 && generation == generation_ &&
+           !paths_.empty() && !uriList_.empty();
+}

--- a/entry/src/main/cpp/rdp/rdp_file_clipboard_offer.h
+++ b/entry/src/main/cpp/rdp/rdp_file_clipboard_offer.h
@@ -1,0 +1,46 @@
+#ifndef RDP_FILE_CLIPBOARD_OFFER_H
+#define RDP_FILE_CLIPBOARD_OFFER_H
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+enum class RdpFileClipboardOfferResult {
+    Ready,
+    Empty,
+    TooManyFiles,
+    InvalidPath
+};
+
+struct RdpFileClipboardOfferSnapshot {
+    uint64_t generation = 0;
+    std::vector<std::string> paths;
+    std::string uriList;
+
+    bool ready() const {
+        return generation != 0 && !paths.empty() && !uriList.empty();
+    }
+};
+
+class RdpFileClipboardOffer {
+public:
+    static constexpr size_t kMaxFilesPerOffer = 15;
+
+    RdpFileClipboardOfferResult replace(const std::vector<std::string>& paths);
+    void clear();
+    RdpFileClipboardOfferSnapshot snapshot() const;
+    bool isCurrent(uint64_t generation) const;
+
+private:
+    static bool isStableAbsolutePath(const std::string& path);
+    static std::string buildUriList(const std::vector<std::string>& paths);
+    void invalidateLocked();
+
+    mutable std::mutex mutex_;
+    uint64_t generation_ = 0;
+    std::vector<std::string> paths_;
+    std::string uriList_;
+};
+
+#endif // RDP_FILE_CLIPBOARD_OFFER_H

--- a/entry/src/main/cpp/test/rdp_file_clipboard_offer_test.cpp
+++ b/entry/src/main/cpp/test/rdp_file_clipboard_offer_test.cpp
@@ -1,0 +1,61 @@
+#include "rdp/rdp_file_clipboard_offer.h"
+#include "test_runner.h"
+
+#include <string>
+#include <vector>
+
+RDP_TEST_CASE(rdp_file_clipboard_offer_builds_freerdp_uri_list) {
+    RdpFileClipboardOffer offer;
+    const auto result = offer.replace({
+        "/data/storage/el2/base/files/rdp_transfer/alpha.txt",
+        "/data/storage/el2/base/files/rdp_transfer/with space.txt"
+    });
+
+    RDP_ASSERT(result == RdpFileClipboardOfferResult::Ready);
+    const auto snapshot = offer.snapshot();
+    RDP_ASSERT(snapshot.ready());
+    RDP_ASSERT_EQ(snapshot.paths.size(), 2U);
+    RDP_ASSERT(snapshot.uriList ==
+               std::string("file:///data/storage/el2/base/files/rdp_transfer/alpha.txt\r\n") +
+               "file:///data/storage/el2/base/files/rdp_transfer/with space.txt\r\n");
+}
+
+RDP_TEST_CASE(rdp_file_clipboard_offer_rejects_unstable_or_unsafe_paths) {
+    RdpFileClipboardOffer offer;
+
+    RDP_ASSERT(offer.replace({}) == RdpFileClipboardOfferResult::Empty);
+    RDP_ASSERT(offer.replace({"relative/file.txt"}) ==
+               RdpFileClipboardOfferResult::InvalidPath);
+    RDP_ASSERT(offer.replace({"/data/storage/file\nname.txt"}) ==
+               RdpFileClipboardOfferResult::InvalidPath);
+    RDP_ASSERT(!offer.snapshot().ready());
+}
+
+RDP_TEST_CASE(rdp_file_clipboard_offer_limits_one_batch_to_fifteen_files) {
+    RdpFileClipboardOffer offer;
+    std::vector<std::string> paths;
+    for (size_t index = 0; index < RdpFileClipboardOffer::kMaxFilesPerOffer + 1; ++index) {
+        paths.push_back("/data/storage/file-" + std::to_string(index));
+    }
+
+    RDP_ASSERT(offer.replace(paths) == RdpFileClipboardOfferResult::TooManyFiles);
+    RDP_ASSERT(!offer.snapshot().ready());
+}
+
+RDP_TEST_CASE(rdp_file_clipboard_offer_generation_invalidates_stale_requests) {
+    RdpFileClipboardOffer offer;
+    RDP_ASSERT(offer.replace({"/data/storage/first.txt"}) ==
+               RdpFileClipboardOfferResult::Ready);
+    const uint64_t firstGeneration = offer.snapshot().generation;
+
+    RDP_ASSERT(offer.replace({"/data/storage/second.txt"}) ==
+               RdpFileClipboardOfferResult::Ready);
+    const uint64_t secondGeneration = offer.snapshot().generation;
+    RDP_ASSERT(secondGeneration > firstGeneration);
+    RDP_ASSERT(!offer.isCurrent(firstGeneration));
+    RDP_ASSERT(offer.isCurrent(secondGeneration));
+
+    offer.clear();
+    RDP_ASSERT(!offer.snapshot().ready());
+    RDP_ASSERT(!offer.isCurrent(secondGeneration));
+}

--- a/entry/src/main/ets/pages/RemoteDesktop.ets
+++ b/entry/src/main/ets/pages/RemoteDesktop.ets
@@ -3,7 +3,8 @@
  */
 import { display, promptAction, router, window } from '@kit.ArkUI';
 import { inputDevice, pointer } from '@kit.InputKit';
-import { common } from '@kit.AbilityKit';
+import { abilityAccessCtrl, common } from '@kit.AbilityKit';
+import { pasteboard } from '@kit.BasicServicesKit';
 import { HostSyncService } from '../services/HostSyncService';
 import { ExtensionLoader } from '../services/ExtensionLoader';
 import { KeyVaultService } from '../services/KeyVaultService';
@@ -96,8 +97,7 @@ import {
 import { hashForLog, maskHost, maskUser, safeError } from '../utils/SafeLogger';
 import { RdpRenderStats, SessionConfig, SessionTransferStatus } from '../types/rdpnapi';
 import { hilog } from '@kit.PerformanceAnalysisKit';
-import { picker } from '@kit.CoreFileKit';
-import { fileIo } from '@kit.CoreFileKit';
+import { fileIo, fileUri, picker } from '@kit.CoreFileKit';
 import { preferences, unifiedDataChannel, uniformDataStruct, uniformTypeDescriptor } from '@kit.ArkData';
 import rdpnapi from 'librdpnapi.so';
 import { util } from '@kit.ArkTS';
@@ -387,6 +387,7 @@ struct RemoteDesktop {
   private externalInputPromptedThisSession: boolean = false;
   private inputDeviceBaselineIds: Array<number> = [];
   private fileTransferHideTimer: number = -1;
+  private rdpClipboardBatchSequence: number = 0;
   private rdpRenderWatchdogTimer: number = -1;
   private rdpNativeStateMonitorTimer: number = -1;
   private lastBrowseModeBlockedToastMs: number = 0;
@@ -3211,6 +3212,23 @@ struct RemoteDesktop {
     }
   }
 
+  private createRdpClipboardBatchDir(): string {
+    const root: string = this.ensureRdpTransferDir();
+    if (root.length === 0) {
+      return '';
+    }
+    this.rdpClipboardBatchSequence = (this.rdpClipboardBatchSequence + 1) % 1000000;
+    const dir: string = root + '/clip_' + Date.now().toString() + '_' +
+      this.rdpClipboardBatchSequence.toString();
+    try {
+      fileIo.mkdirSync(dir);
+      return dir;
+    } catch (_err) {
+      hilog.error(RD_DOMAIN, RD_TAG, 'failed to create isolated RDP clipboard batch');
+      return '';
+    }
+  }
+
   private sanitizedRdpDriveName(): string {
     let out: string = '';
     const source: string = this.rdpDriveName.length > 0 ? this.rdpDriveName : RDP_TRANSFER_DRIVE_NAME;
@@ -3346,31 +3364,16 @@ struct RemoteDesktop {
       createTransferSnapshot(taskId, protocol, fileName, total, total, 'completed', statusText));
   }
 
-  private async copyFileToRdpDrive(uri: string, fileName: string, fileSize: number): Promise<TransferState> {
-    if (!RDP_DRIVE_REDIRECTION_ENABLED) {
-      this.setFileTransferStatus('[RDP-FILE] RDP 文件传输当前不可用。请使用 RustDesk 文件传输或 SSH SFTP。', -1, false);
-      promptAction.showToast({
-        message: 'RDP 文件传输暂未启用',
-        duration: 3600
-      });
-      return 'failed';
-    }
-    if (!this.rdpDriveEnabled) {
-      this.setFileTransferStatus('[RDP-FILE] RDP 文件传输尚未启用，请完成设置后重新连接。', -1, false);
-      promptAction.showToast({
-        message: '请完成 RDP 文件传输设置后重新连接',
-        duration: 3600
-      });
-      return 'failed';
-    }
-    const dir: string = this.ensureRdpTransferDir();
+  private async stageFileForRdpClipboard(uri: string, fileName: string, fileSize: number,
+    batchDir: string = ''): Promise<string> {
+    const dir: string = batchDir.length > 0 ? batchDir : this.createRdpClipboardBatchDir();
     if (dir.length === 0) {
       this.setFileTransferStatus('[RDP-FILE] RDP 文件传输准备失败', -1, false);
-      return 'failed';
+      return '';
     }
     if (fileSize <= 0 || fileSize > RDP_FILE_MAX_BYTES) {
       this.setFileTransferStatus('[RDP-FILE] 文件为空或超过 2GB', -1, false);
-      return 'failed';
+      return '';
     }
     let src: fileIo.File | null = null;
     let dst: fileIo.File | null = null;
@@ -3394,7 +3397,7 @@ struct RemoteDesktop {
           this.setFileTransferStatus('[RDP-FILE] 文件读取中断', -1, false);
           await this.finishLiveFileTransfer(liveTaskId, 'rdp', '文件', copied, fileSize, true,
             '[RDP-FILE] 文件读取中断');
-          return 'failed';
+          return '';
         }
         const payload: ArrayBuffer = readLen === chunkSize ? chunk : chunk.slice(0, readLen);
         const written: number = fileIo.writeSync(dst.fd, payload);
@@ -3402,7 +3405,7 @@ struct RemoteDesktop {
           this.setFileTransferStatus('[RDP-FILE] RDP 文件传输写入不完整', -1, false);
           await this.finishLiveFileTransfer(liveTaskId, 'rdp', '文件', copied, fileSize, true,
             '[RDP-FILE] RDP 文件传输写入不完整');
-          return 'failed';
+          return '';
         }
         copied += readLen;
         const progress: number = Math.min(1, copied / fileSize);
@@ -3415,21 +3418,16 @@ struct RemoteDesktop {
         }
         await this.yieldUi(0);
       }
-      const doneStatus: string = 'RDP 文件传输已完成';
-      this.setFileTransferStatus(doneStatus, 1, false);
-      await this.finishLiveFileTransfer(liveTaskId, 'rdp', '文件', fileSize, fileSize, false, doneStatus);
-      promptAction.showToast({
-        message: 'RDP 文件传输已完成',
-        duration: 3600
-      });
-      hilog.info(RD_DOMAIN, RD_TAG, 'rdp file transfer completed size=' + fileSize.toString());
-      return 'completed';
+      const readyStatus: string = 'RDP 文件已暂存，正在发布到远端剪贴板';
+      await this.finishLiveFileTransfer(liveTaskId, 'rdp', '文件', fileSize, fileSize, false, readyStatus);
+      hilog.info(RD_DOMAIN, RD_TAG, 'rdp clipboard file staged size=' + fileSize.toString());
+      return targetPath;
     } catch (_err) {
       this.setFileTransferStatus('[RDP-FILE] 文件传输失败 [' + FILE_TRANSFER_DIAG_RDP_COPY + ']', -1, false);
       await this.finishLiveFileTransfer(liveTaskId, 'rdp', '文件', copied, fileSize, true,
         '[RDP-FILE] 文件传输失败 [' + FILE_TRANSFER_DIAG_RDP_COPY + ']');
       hilog.error(RD_DOMAIN, RD_TAG, 'file transfer diagnostic=' + FILE_TRANSFER_DIAG_RDP_COPY);
-      return 'failed';
+      return '';
     } finally {
       if (src !== null) {
         try { fileIo.closeSync(src); } catch (_err2) { /* ignore */ }
@@ -3539,7 +3537,16 @@ struct RemoteDesktop {
       metaFile = null;
 
       if (this.pendingHost.protocol === 'rdp') {
-        await this.copyFileToRdpDrive(uri, fileName, fileSize);
+        const stagedPath: string = await this.stageFileForRdpClipboard(uri, fileName, fileSize);
+        if (stagedPath.length === 0 ||
+          !this.loader.setSessionClipboardFiles(this.sessionId, [stagedPath])) {
+          this.setFileTransferStatus('[RDP-FILE] 远端文件剪贴板发布失败', -1, false);
+          return;
+        }
+        this.keyDispatcher.sendShortcutSequence(this.loader, this.sessionId,
+          [KEYCODE_CTRL_LEFT, KEY_V], 'RDP file paste');
+        this.setFileTransferStatus('已发送到远端当前位置，Windows 正在读取文件', 1, false);
+        promptAction.showToast({ message: '已发送到远端当前位置', duration: 2200 });
       } else if (this.pendingHost.protocol === 'rustdesk') {
         await this.submitFileToRustDesk(uri, fileName, fileSize);
       } else {
@@ -3552,6 +3559,174 @@ struct RemoteDesktop {
       if (metaFile !== null) {
         try { fileIo.closeSync(metaFile); } catch (_err2) { /* ignore */ }
       }
+    }
+  }
+
+  private systemPasteboardHasFileUri(): boolean {
+    try {
+      return pasteboard.getSystemPasteboard().hasDataType(pasteboard.MIMETYPE_TEXT_URI);
+    } catch (_err) {
+      return false;
+    }
+  }
+
+  private async ensurePasteboardReadPermission(): Promise<boolean> {
+    try {
+      const ctx: common.UIAbilityContext = getContext(this) as common.UIAbilityContext;
+      const manager: abilityAccessCtrl.AtManager = abilityAccessCtrl.createAtManager();
+      const status: abilityAccessCtrl.GrantStatus = manager.checkAccessTokenSync(
+        ctx.applicationInfo.accessTokenId, 'ohos.permission.READ_PASTEBOARD');
+      if (status === abilityAccessCtrl.GrantStatus.PERMISSION_GRANTED) {
+        return true;
+      }
+      const result = await manager.requestPermissionsFromUser(ctx,
+        ['ohos.permission.READ_PASTEBOARD']);
+      return result.authResults.length > 0 && result.authResults[0] === 0;
+    } catch (_err) {
+      hilog.warn(RD_DOMAIN, RD_TAG, 'RDP file clipboard read permission unavailable');
+      return false;
+    }
+  }
+
+  private async handleRdpSystemFilePaste(): Promise<void> {
+    if (this.fileTransferBusy || !this.connected || this.sessionId <= 0 ||
+      !this.pendingHost || this.pendingHost.protocol !== 'rdp') {
+      return;
+    }
+    if (!await this.ensurePasteboardReadPermission()) {
+      promptAction.showToast({ message: '需要剪贴板权限才能粘贴本机文件', duration: 2600 });
+      return;
+    }
+    try {
+      const data: unifiedDataChannel.UnifiedData =
+        await pasteboard.getSystemPasteboard().getUnifiedData();
+      const records: Array<unifiedDataChannel.UnifiedRecord> = data.getRecords();
+      if (records.length === 0 || records.length > 15) {
+        this.setFileTransferStatus(records.length > 15 ?
+          '[RDP-FILE] 单次最多粘贴 15 个文件' : '[RDP-FILE] 剪贴板中没有可传输文件', -1, false);
+        return;
+      }
+      const batchDir: string = this.createRdpClipboardBatchDir();
+      if (batchDir.length === 0) {
+        return;
+      }
+      const stagedPaths: string[] = [];
+      for (const record of records) {
+        const fileUriEntry: uniformDataStruct.FileUri =
+          record.getEntry(uniformTypeDescriptor.UniformDataType.FILE_URI) as uniformDataStruct.FileUri;
+        const uri: string = fileUriEntry && fileUriEntry.oriUri ? fileUriEntry.oriUri : '';
+        if (uri.length === 0) {
+          continue;
+        }
+        let metaFile: fileIo.File | null = null;
+        try {
+          metaFile = fileIo.openSync(uri, fileIo.OpenMode.READ_ONLY);
+          const fileSize: number = fileIo.statSync(metaFile.fd).size;
+          fileIo.closeSync(metaFile);
+          metaFile = null;
+          const stagedPath: string = await this.stageFileForRdpClipboard(
+            uri, this.fileBaseName(uri), fileSize, batchDir);
+          if (stagedPath.length > 0) {
+            stagedPaths.push(stagedPath);
+          }
+        } catch (_err) {
+          hilog.warn(RD_DOMAIN, RD_TAG, 'RDP clipboard file metadata unavailable');
+        } finally {
+          if (metaFile !== null) {
+            try { fileIo.closeSync(metaFile); } catch (_err2) { /* ignore */ }
+          }
+        }
+      }
+      if (stagedPaths.length === 0 ||
+        !this.loader.setSessionClipboardFiles(this.sessionId, stagedPaths)) {
+        this.setFileTransferStatus('[RDP-FILE] 远端文件剪贴板发布失败', -1, false);
+        return;
+      }
+      this.keyDispatcher.sendShortcutSequence(this.loader, this.sessionId,
+        [KEYCODE_CTRL_LEFT, KEY_V], 'RDP system file paste');
+      this.setFileTransferStatus('Windows 正在从本机读取 ' + stagedPaths.length.toString() + ' 个文件', 1, false);
+    } catch (_err) {
+      this.setFileTransferStatus('[RDP-FILE] 无法读取系统文件剪贴板', -1, false);
+    }
+  }
+
+  private async publishDeferredRdpDrop(data: unifiedDataChannel.UnifiedData): Promise<void> {
+    try {
+      const records: Array<unifiedDataChannel.UnifiedRecord> = data.getRecords();
+      if (records.length === 0 || records.length > 15) {
+        this.setFileTransferStatus(records.length > 15 ?
+          '[RDP-FILE] 单次最多拖入 15 个文件' : '[RDP-FILE] 文件中转站未返回文件', -1, false);
+        return;
+      }
+      const stableDir: string = this.ensureRdpTransferDir();
+      const stablePrefix: string = stableDir + '/';
+      const paths: string[] = [];
+      for (const record of records) {
+        const entry: uniformDataStruct.FileUri =
+          record.getEntry(uniformTypeDescriptor.UniformDataType.FILE_URI) as uniformDataStruct.FileUri;
+        const uri: string = entry && entry.oriUri ? entry.oriUri : '';
+        if (uri.length === 0) {
+          continue;
+        }
+        const path: string = new fileUri.FileUri(uri).path;
+        if (!path.startsWith(stablePrefix)) {
+          hilog.warn(RD_DOMAIN, RD_TAG, 'deferred RDP drop returned path outside staging directory');
+          continue;
+        }
+        const stat = fileIo.statSync(path);
+        if (stat.size > 0 && stat.size <= RDP_FILE_MAX_BYTES) {
+          paths.push(path);
+        }
+      }
+      if (paths.length === 0 || !this.loader.setSessionClipboardFiles(this.sessionId, paths)) {
+        this.setFileTransferStatus('[RDP-FILE] 文件中转站内容发布失败', -1, false);
+        return;
+      }
+      this.keyDispatcher.sendShortcutSequence(this.loader, this.sessionId,
+        [KEYCODE_CTRL_LEFT, KEY_V], 'RDP SuperHub file paste');
+      this.setFileTransferStatus('Windows 正在读取文件中转站的 ' + paths.length.toString() + ' 个文件', 1, false);
+    } catch (_err) {
+      this.setFileTransferStatus('[RDP-FILE] 文件中转站数据处理失败', -1, false);
+    }
+  }
+
+  private startDeferredRdpFileDrop(event: DragEvent): void {
+    if (!this.pendingHost || this.pendingHost.protocol !== 'rdp') {
+      this.setFileTransferStatus('移动端文件中转站当前仅支持 RDP', -1, false);
+      event.setResult(DragResult.DRAG_FAILED);
+      return;
+    }
+    const destPath: string = this.createRdpClipboardBatchDir();
+    if (destPath.length === 0) {
+      event.setResult(DragResult.DRAG_FAILED);
+      return;
+    }
+    const listener: unifiedDataChannel.DataProgressListener =
+      (progress: unifiedDataChannel.ProgressInfo,
+        data: unifiedDataChannel.UnifiedData | null): void => {
+        if (progress.progress >= 0 && progress.progress < 100) {
+          this.setFileTransferStatus('正在从文件中转站获取文件 ' +
+            progress.progress.toString() + '%', progress.progress / 100, true);
+        }
+        if (progress.progress === 100 && data !== null) {
+          this.publishDeferredRdpDrop(data);
+        } else if (progress.progress < 0) {
+          this.setFileTransferStatus('[RDP-FILE] 文件中转站数据获取失败', -1, false);
+        }
+      };
+    const options: DataSyncOptions = {
+      destUri: fileUri.getUriFromPath(destPath),
+      fileConflictOptions: unifiedDataChannel.FileConflictOptions.OVERWRITE,
+      progressIndicator: unifiedDataChannel.ProgressIndicator.DEFAULT,
+      dataProgressListener: listener
+    };
+    try {
+      event.startDataLoading(options);
+      event.setResult(DragResult.DRAG_SUCCESSFUL);
+      this.setFileTransferStatus('正在从文件中转站获取文件', 0, true);
+    } catch (_err) {
+      event.setResult(DragResult.DRAG_FAILED);
+      this.setFileTransferStatus('[RDP-FILE] 无法启动文件中转站数据加载', -1, false);
     }
   }
 
@@ -3569,6 +3744,10 @@ struct RemoteDesktop {
       promptAction.showToast({ message: 'RustDesk 文件粘贴已禁用', duration: 1600 });
       return;
     }
+    if (!this.isDesktopDevice || this.breakpoint !== 'xl') {
+      this.startDeferredRdpFileDrop(event);
+      return;
+    }
     try {
       const data: unifiedDataChannel.UnifiedData = event.getData();
       const records: Array<unifiedDataChannel.UnifiedRecord> = data.getRecords();
@@ -3576,10 +3755,21 @@ struct RemoteDesktop {
       if (totalCount <= 0) {
         return;
       }
+      if (this.pendingHost.protocol === 'rdp' && totalCount > 15) {
+        this.setFileTransferStatus('[RDP-FILE] 单次最多拖入 15 个文件', -1, false);
+        promptAction.showToast({ message: '单次最多拖入 15 个文件', duration: 2200 });
+        return;
+      }
       hilog.info(RD_DOMAIN, RD_TAG, 'drop-files count=' + totalCount.toString() +
         ' protocol=' + this.pendingHost.protocol);
       let completedCount: number = 0;
       let pendingRemoteCount: number = 0;
+      const rdpBatchDir: string = this.pendingHost.protocol === 'rdp' ?
+        this.createRdpClipboardBatchDir() : '';
+      if (this.pendingHost.protocol === 'rdp' && rdpBatchDir.length === 0) {
+        return;
+      }
+      const rdpStagedPaths: string[] = [];
       for (const record of records) {
         // UDMF: 文件数据存储在 FILE_URI 条目中
         const fileUriEntry: uniformDataStruct.FileUri =
@@ -3607,7 +3797,10 @@ struct RemoteDesktop {
         }
         if (totalCount > 1) {
           if (this.pendingHost.protocol === 'rdp') {
-            this.setFileTransferStatus('RDP 文件传输当前不可用', -1, false);
+            this.setFileTransferStatus(
+              '[' + (completedCount + 1).toString() + '/' + totalCount.toString() + '] 正在暂存 ' +
+              fileName + ' (' + this.formatTransferSize(fileSize) + ')',
+              completedCount / totalCount, true);
           } else {
             this.setFileTransferStatus(
               '[' + (completedCount + 1).toString() + '/' + totalCount.toString() + '] 正在传输 ' +
@@ -3617,7 +3810,12 @@ struct RemoteDesktop {
         }
         let transferState: TransferState = 'failed';
         if (this.pendingHost.protocol === 'rdp') {
-          transferState = await this.copyFileToRdpDrive(uri, fileName, fileSize);
+          const stagedPath: string = await this.stageFileForRdpClipboard(
+            uri, fileName, fileSize, rdpBatchDir);
+          if (stagedPath.length > 0) {
+            rdpStagedPaths.push(stagedPath);
+            transferState = 'completed';
+          }
         } else if (this.pendingHost.protocol === 'rustdesk') {
           transferState = await this.submitFileToRustDesk(uri, fileName, fileSize);
         } else {
@@ -3629,6 +3827,16 @@ struct RemoteDesktop {
         } else if (transferState === 'waitingRemote') {
           pendingRemoteCount++;
         }
+      }
+      if (this.pendingHost.protocol === 'rdp' && rdpStagedPaths.length > 0) {
+        if (!this.loader.setSessionClipboardFiles(this.sessionId, rdpStagedPaths)) {
+          this.setFileTransferStatus('[RDP-FILE] 远端文件剪贴板发布失败', -1, false);
+          return;
+        }
+        this.keyDispatcher.sendShortcutSequence(this.loader, this.sessionId,
+          [KEYCODE_CTRL_LEFT, KEY_V], 'RDP drop file paste');
+        this.setFileTransferStatus('已发送到远端当前位置，Windows 正在读取 ' +
+          rdpStagedPaths.length.toString() + ' 个文件', 1, false);
       }
       if (completedCount > 0) {
         event.setResult(DragResult.DRAG_SUCCESSFUL);
@@ -4476,6 +4684,7 @@ struct RemoteDesktop {
   private physicalAltDown: boolean = false;
   private physicalShiftDown: boolean = false;
   private physicalWinDown: boolean = false;
+  private rdpFilePasteKeyIntercepted: boolean = false;
 
   private isPhysicalModifierKey(keyCode: number): boolean {
     return keyCode === KEYCODE_CTRL_LEFT || keyCode === KEYCODE_CTRL_RIGHT ||
@@ -4521,6 +4730,21 @@ struct RemoteDesktop {
         return;
       }
       const kc: number = event.keyCode;
+
+      if (kc === KEY_V && isUp && this.rdpFilePasteKeyIntercepted) {
+        this.rdpFilePasteKeyIntercepted = false;
+        return;
+      }
+      if (kc === KEY_V && isDown && this.physicalCtrlDown &&
+        !this.physicalAltDown && !this.physicalShiftDown && !this.physicalWinDown &&
+        this.pendingHost !== null && this.pendingHost.protocol === 'rdp' &&
+        this.systemPasteboardHasFileUri()) {
+        this.rdpFilePasteKeyIntercepted = true;
+        this.loader.sendKey(this.sessionId, KEYCODE_CTRL_LEFT, false);
+        this.loader.sendKey(this.sessionId, KEYCODE_CTRL_RIGHT, false);
+        this.handleRdpSystemFilePaste();
+        return;
+      }
 
       // 物理修饰键: 跟踪状态 + 发送 down/up
       if (this.isPhysicalModifierKey(kc)) {
@@ -4738,13 +4962,10 @@ struct RemoteDesktop {
         .onTouch(this.handleConfiguredTouchInput)
         .onMouse(this.handleXComponentMouse)
         .onKeyEvent(this.handleXComponentKey)
-        .allowDrop(this.isDesktopDevice && this.breakpoint === 'xl' ?
-          [uniformTypeDescriptor.UniformDataType.FILE] : null)
+        .allowDrop([uniformTypeDescriptor.UniformDataType.FILE])
         .onDragEnter((event: DragEvent): void => {
-          if (this.isDesktopDevice && this.breakpoint === 'xl') {
-            this.dropHoverActive = true;
-            hilog.info(RD_DOMAIN, RD_TAG, 'drop-enter');
-          }
+          this.dropHoverActive = true;
+          hilog.info(RD_DOMAIN, RD_TAG, 'drop-enter');
         })
         .onDragLeave((event: DragEvent): void => {
           this.dropHoverActive = false;
@@ -4752,11 +4973,9 @@ struct RemoteDesktop {
         })
         .onDrop((event: DragEvent): void => {
           this.dropHoverActive = false;
-          if (this.isDesktopDevice && this.breakpoint === 'xl') {
-            hilog.info(RD_DOMAIN, RD_TAG, 'drop-file received');
-            this.handleFileDrop(event);
-          }
-        })
+          hilog.info(RD_DOMAIN, RD_TAG, 'drop-file received');
+          this.handleFileDrop(event);
+        }, { disableDataPrefetch: !this.isDesktopDevice || this.breakpoint !== 'xl' })
       }
 
       if (this.connected && this.shouldShowRustDeskSessionTopBar()) {

--- a/entry/src/main/ets/pages/RustDeskRelayPage.ets
+++ b/entry/src/main/ets/pages/RustDeskRelayPage.ets
@@ -16,6 +16,7 @@ import { socket } from '@kit.NetworkKit';
 import { RustDeskRelayConfig } from '../model/RustDeskRelayConfig';
 import { RustDeskAccount } from '../model/RustDeskAccount';
 import { HostSyncService } from '../services/HostSyncService';
+import { snapshotSelectedRelay } from '../services/RustDeskRelayHealthPolicy';
 import { Palette, buildDark, buildLight, AppTheme } from '../common/Theme';
 
 class TcpTestResult {
@@ -90,7 +91,14 @@ export struct RustDeskRelayPage {
       });
     }
   }
-  private load(): void { this.relays = this.srv.getAllRelays(); }
+  private load(): void {
+    const selectedRelayId = this.selectedPcRelay ? this.selectedPcRelay.id : '';
+    const nextRelays = this.srv.getAllRelays();
+    this.relays = nextRelays;
+    if (selectedRelayId !== '') {
+      this.selectedPcRelay = snapshotSelectedRelay(nextRelays, selectedRelayId);
+    }
+  }
   onAddTrigger(): void {
     if (this.addTrigger > 0) { this.openAddRelaySheet(); }
   }

--- a/entry/src/main/ets/services/ExtensionLoader.ets
+++ b/entry/src/main/ets/services/ExtensionLoader.ets
@@ -599,6 +599,15 @@ export class ExtensionLoader {
     }
   }
 
+  setSessionClipboardFiles(sessionId: number, paths: string[]): boolean {
+    try {
+      return rdpnapi.setSessionClipboardFiles(sessionId, paths) as boolean;
+    } catch (err) {
+      hilog.error(DOMAIN, TAG, '[ExtensionLoader] setSessionClipboardFiles: ' + JSON.stringify(err));
+      return false;
+    }
+  }
+
   readData(sessionId: number): string {
     try {
       const result: string = rdpnapi.readData(sessionId) as string;

--- a/entry/src/main/ets/services/RemoteSessionCapabilityPolicy.ets
+++ b/entry/src/main/ets/services/RemoteSessionCapabilityPolicy.ets
@@ -73,7 +73,7 @@ export function resolveSessionCapabilities(state: SessionCapabilityState): Remot
       connect,
       clipboardSend: available(),
       clipboardReceive: inbound,
-      fileUpload: drive,
+      fileUpload: state.rdpClipboardReady ? available() : unavailable('RDP 文件剪贴板通道尚未就绪'),
       fileDownload: drive,
       multiDisplay: unavailable('当前 RDP 渲染仅支持单显示器')
     };

--- a/entry/src/main/ets/services/RustDeskRelayHealthPolicy.ets
+++ b/entry/src/main/ets/services/RustDeskRelayHealthPolicy.ets
@@ -1,0 +1,16 @@
+import { RustDeskRelayConfig } from '../model/RustDeskRelayConfig';
+
+/**
+ * Create a fresh selected-relay object from the current list entry.
+ *
+ * Relay health is updated on the service-owned config object. The PC detail
+ * panel keeps its own @State reference, so replacing that reference is
+ * required for ArkUI to render the new latency and status immediately.
+ */
+export function snapshotSelectedRelay(
+  relays: RustDeskRelayConfig[],
+  selectedRelayId: string
+): RustDeskRelayConfig | null {
+  const source = relays.find((relay: RustDeskRelayConfig): boolean => relay.id === selectedRelayId);
+  return source ? RustDeskRelayConfig.fromJSON(source.toJSON()) : null;
+}

--- a/entry/src/main/ets/types/rdpnapi.d.ts
+++ b/entry/src/main/ets/types/rdpnapi.d.ts
@@ -26,6 +26,7 @@ declare module 'librdpnapi.so' {
   export function makeRemoteDir(sessionId: number, remotePath: string): number;
   export function renameRemotePath(sessionId: number, oldPath: string, newPath: string): number;
   export function sendClipboard(sessionId: number, data: ArrayBuffer): void;
+  export function setSessionClipboardFiles(sessionId: number, paths: string[]): boolean;
   export function getSessionClipboardText(sessionId: number): string;
   export function isSessionClipboardReady(sessionId: number): boolean;
 

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -52,14 +52,17 @@
       {
         "name": "ohos.permission.KEEP_BACKGROUND_RUNNING"
       },
-      {
-        "name": "ohos.permission.READ_PASTEBOARD",
-        "reason": "$string:pasteboard_permission_reason",
-        "usedScene": {
-          "abilities": ["EntryAbility"],
-          "when": "inuse"
-        }
-      },
+      // Temporarily disabled until the READ_PASTEBOARD ACL request is approved.
+      // Restore this declaration together with an ACL-enabled signing profile
+      // before validating the RDP system file paste flow.
+      // {
+      //   "name": "ohos.permission.READ_PASTEBOARD",
+      //   "reason": "$string:pasteboard_permission_reason",
+      //   "usedScene": {
+      //     "abilities": ["EntryAbility"],
+      //     "when": "inuse"
+      //   }
+      // },
       {
         "name": "ohos.permission.CAMERA",
         "reason": "$string:camera_permission_reason",

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -52,8 +52,14 @@
       {
         "name": "ohos.permission.KEEP_BACKGROUND_RUNNING"
       },
-      // Temporarily disabled for emulator deployment: this restricted permission
-      // requires an ACL-enabled signing profile. Restore it for RDP system-file paste.
+      {
+        "name": "ohos.permission.READ_PASTEBOARD",
+        "reason": "$string:pasteboard_permission_reason",
+        "usedScene": {
+          "abilities": ["EntryAbility"],
+          "when": "inuse"
+        }
+      },
       {
         "name": "ohos.permission.CAMERA",
         "reason": "$string:camera_permission_reason",

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -53,6 +53,14 @@
         "name": "ohos.permission.KEEP_BACKGROUND_RUNNING"
       },
       {
+        "name": "ohos.permission.READ_PASTEBOARD",
+        "reason": "$string:pasteboard_permission_reason",
+        "usedScene": {
+          "abilities": ["EntryAbility"],
+          "when": "inuse"
+        }
+      },
+      {
         "name": "ohos.permission.CAMERA",
         "reason": "$string:camera_permission_reason",
         "usedScene": {

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -52,14 +52,8 @@
       {
         "name": "ohos.permission.KEEP_BACKGROUND_RUNNING"
       },
-      {
-        "name": "ohos.permission.READ_PASTEBOARD",
-        "reason": "$string:pasteboard_permission_reason",
-        "usedScene": {
-          "abilities": ["EntryAbility"],
-          "when": "inuse"
-        }
-      },
+      // Temporarily disabled for emulator deployment: this restricted permission
+      // requires an ACL-enabled signing profile. Restore it for RDP system-file paste.
       {
         "name": "ohos.permission.CAMERA",
         "reason": "$string:camera_permission_reason",

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -41,6 +41,10 @@
       "value": "用于扫描二维码添加 2FA 验证器，不会拍摄照片或视频，仅在您主动点击扫描按钮时启用"
     },
     {
+      "name": "pasteboard_permission_reason",
+      "value": "仅在您于远程桌面中粘贴文件时读取系统剪贴板中的文件地址，用于将所选文件传输到远端"
+    },
+    {
       "name": "datasync_reason",
       "value": "用于跨设备同步远程主机配置"
     },

--- a/entry/src/ohosTest/ets/test/List.test.ets
+++ b/entry/src/ohosTest/ets/test/List.test.ets
@@ -12,6 +12,7 @@ import hostSyncServiceTest from './HostSyncService.test';
 import remoteRestoreFrameRefreshPolicyTest from './RemoteRestoreFrameRefreshPolicy.test';
 import safeLoggerTest from './SafeLogger.test';
 import rustDeskHostConfigPolicyTest from './RustDeskHostConfigPolicy.test';
+import rustDeskRelayHealthPolicyTest from './RustDeskRelayHealthPolicy.test';
 import backgroundVideoPrewarmPolicyTest from './BackgroundVideoPrewarmPolicy.test';
 import remoteImeSessionPolicyTest from './RemoteImeSessionPolicy.test';
 import remoteImeCommandQueueTest from './RemoteImeCommandQueue.test';
@@ -35,6 +36,7 @@ export default function testsuite() {
   hostSyncServiceTest();
   safeLoggerTest();
   rustDeskHostConfigPolicyTest();
+  rustDeskRelayHealthPolicyTest();
   backgroundVideoPrewarmPolicyTest();
   remoteImeSessionPolicyTest();
   remoteImeCommandQueueTest();

--- a/entry/src/ohosTest/ets/test/RustDeskRelayHealthPolicy.test.ets
+++ b/entry/src/ohosTest/ets/test/RustDeskRelayHealthPolicy.test.ets
@@ -1,0 +1,35 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { RustDeskRelayConfig } from '../../../main/ets/model/RustDeskRelayConfig';
+import { snapshotSelectedRelay } from '../../../main/ets/services/RustDeskRelayHealthPolicy';
+
+function relayWithLatency(latency: number): RustDeskRelayConfig {
+  const relay = new RustDeskRelayConfig();
+  relay.id = 'relay-health-test';
+  relay.idServer = 'id.example.com';
+  relay.relayServer = 'relay.example.com';
+  relay.healthStatus = 'online';
+  relay.healthLatency = latency;
+  relay.healthCheckedAt = Date.now();
+  return relay;
+}
+
+export default function rustDeskRelayHealthPolicyTest(): void {
+  describe('RustDeskRelayHealthPolicy', (): void => {
+    it('selected_relay_snapshot_should_refresh_latest_latency', 0, (): void => {
+      const source = relayWithLatency(120);
+      const first = snapshotSelectedRelay([source], source.id);
+      expect(first !== null).assertTrue();
+      expect((first as RustDeskRelayConfig).healthLatency).assertEqual(120);
+
+      source.healthLatency = 34;
+      const refreshed = snapshotSelectedRelay([source], source.id);
+      expect(refreshed !== null).assertTrue();
+      expect((refreshed as RustDeskRelayConfig).healthLatency).assertEqual(34);
+      expect((refreshed as RustDeskRelayConfig) === source).assertFalse();
+    });
+
+    it('missing_selected_relay_should_return_null', 0, (): void => {
+      expect(snapshotSelectedRelay([relayWithLatency(20)], 'missing') === null).assertTrue();
+    });
+  });
+}

--- a/entry/src/test/RemoteSessionCapabilityPolicy.test.ets
+++ b/entry/src/test/RemoteSessionCapabilityPolicy.test.ets
@@ -12,12 +12,12 @@ export default function remoteSessionCapabilityPolicyTest(): void {
       expect(capabilities.connect.reason).assertEqual('当前版本尚未提供 VNC 连接支持');
     });
 
-    it('rdp_should_not_offer_file_transfer_before_drive_mount', 0, (): void => {
+    it('rdp_should_offer_clipboard_upload_without_drive_mount', 0, (): void => {
       const capabilities = resolveSessionCapabilities({
-        protocol: 'rdp', connected: true, rdpDriveMounted: false, rdpClipboardReady: false, sftpConnected: false,
+        protocol: 'rdp', connected: true, rdpDriveMounted: false, rdpClipboardReady: true, sftpConnected: false,
         rustDeskVerifiedPeer: false, rustDeskInboundClipboard: false, rustDeskTransferConfirmed: false
       });
-      expect(capabilities.fileUpload.enabled).assertFalse();
+      expect(capabilities.fileUpload.enabled).assertTrue();
       expect(capabilities.fileDownload.enabled).assertFalse();
     });
 

--- a/rustdesk_ffi/src/connector.rs
+++ b/rustdesk_ffi/src/connector.rs
@@ -17,6 +17,7 @@
 use crate::crypto::{self, KeyPair};
 use crate::crypto_channel::CryptoChannel;
 use crate::control_inbox::{CONTROL_BATCH_LIMIT, ControlInbox};
+use crate::net;
 use crate::protocol::message_proto::{
     AudioFormat, AudioFrame, Clipboard, ClipboardFormat, ControlKey, EncodedVideoFrames,
     FileAction, FileAction_oneof_union, FileEntry, FileResponse, FileResponse_oneof_union,
@@ -244,12 +245,14 @@ impl RustDeskConnector {
     ) -> io::Result<()> {
         // === Phase 1: TCP 直连 peer ===
         self.state = ConnState::ConnectingToPeer;
-        let addr = format!("{}:{}", peer_host, peer_port);
-        eprintln!("[RustDesk-FFI] direct connect to peer {}", addr);
-        let mut stream = TcpStream::connect_timeout(
-            &addr
-                .parse()
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
+        eprintln!(
+            "[RustDesk-FFI] direct connect to peer {}:{}",
+            peer_host, peer_port
+        );
+        let mut stream = net::connect_tcp_host(
+            peer_host,
+            peer_port,
+            "direct",
             Duration::from_secs(10),
         )?;
         stream.set_read_timeout(Some(Duration::from_secs(30)))?;
@@ -2053,6 +2056,8 @@ mod tests {
         should_refresh_for_video_starvation, ControlKey, KeyEvent_oneof_union, Message_oneof_union,
         RustDeskConnector,
     };
+    use std::net::TcpListener;
+    use std::thread;
 
     #[test]
     fn video_starvation_refreshes_when_audio_is_alive() {
@@ -2178,5 +2183,29 @@ mod tests {
             start,
             start + std::time::Duration::from_secs(5)
         ));
+    }
+
+    #[test]
+    fn direct_connect_resolves_hostname_before_peer_handshake() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener bind failed");
+        let port = listener
+            .local_addr()
+            .expect("listener address missing")
+            .port();
+        let accept_thread = thread::spawn(move || {
+            let _ = listener
+                .accept()
+                .expect("direct hostname connection was not accepted");
+        });
+
+        let error = RustDeskConnector::new()
+            .connect_direct("localhost", port, "", 0, 1, false, false, 30)
+            .expect_err("fake peer should fail after TCP connect, not during endpoint parsing");
+        assert_ne!(
+            error.kind(),
+            std::io::ErrorKind::InvalidInput,
+            "hostname should be resolved before the direct protocol is read"
+        );
+        accept_thread.join().expect("accept thread panicked");
     }
 }

--- a/rustdesk_ffi/src/lib.rs
+++ b/rustdesk_ffi/src/lib.rs
@@ -24,6 +24,7 @@ pub mod connector;
 pub mod crypto;
 pub mod crypto_channel;
 mod control_inbox;
+mod net;
 #[cfg(feature = "opus-audio")]
 pub mod opus_ffi;
 pub mod protocol;

--- a/rustdesk_ffi/src/net.rs
+++ b/rustdesk_ffi/src/net.rs
@@ -1,0 +1,282 @@
+//! TCP endpoint parsing and DNS-aware connection helpers for RustDesk.
+
+use std::io;
+use std::net::{TcpStream, ToSocketAddrs};
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedEndpoint {
+    host: String,
+    port: u16,
+}
+
+/// Connect to a host and port, resolving DNS and trying every candidate address.
+pub(crate) fn connect_tcp_host(
+    host: &str,
+    port: u16,
+    stage: &str,
+    timeout: Duration,
+) -> io::Result<TcpStream> {
+    let host = normalize_host(host, stage)?;
+    validate_port(port, stage, &host)?;
+    connect_parsed_endpoint(ParsedEndpoint { host, port }, stage, timeout)
+}
+
+/// Connect to an endpoint that may contain an explicit port.
+pub(crate) fn connect_tcp_endpoint(
+    endpoint: &str,
+    default_port: u16,
+    stage: &str,
+    timeout: Duration,
+) -> io::Result<TcpStream> {
+    let parsed = parse_endpoint(endpoint, default_port, stage)?;
+    connect_parsed_endpoint(parsed, stage, timeout)
+}
+
+fn normalize_host(host: &str, stage: &str) -> io::Result<String> {
+    let host = host.trim();
+    if host.is_empty() {
+        return Err(invalid_endpoint(stage, host, "host is empty"));
+    }
+    if has_uri_or_path(host) {
+        return Err(invalid_endpoint(
+            stage,
+            host,
+            "URL schemes and paths are not valid TCP hosts",
+        ));
+    }
+    if host.starts_with('[') || host.ends_with(']') {
+        if host.starts_with('[') && host.ends_with(']') && host.len() > 2 {
+            return Ok(host[1..host.len() - 1].to_string());
+        }
+        return Err(invalid_endpoint(stage, host, "invalid bracketed host"));
+    }
+    if host.chars().any(char::is_whitespace) {
+        return Err(invalid_endpoint(stage, host, "host contains whitespace"));
+    }
+    if host.contains(':') && host.parse::<std::net::SocketAddr>().is_ok() {
+        return Err(invalid_endpoint(
+            stage,
+            host,
+            "host must not include a port; pass port separately",
+        ));
+    }
+    Ok(host.to_string())
+}
+
+fn parse_endpoint(endpoint: &str, default_port: u16, stage: &str) -> io::Result<ParsedEndpoint> {
+    let endpoint = endpoint.trim();
+    if endpoint.is_empty() {
+        return Err(invalid_endpoint(stage, endpoint, "endpoint is empty"));
+    }
+    if has_uri_or_path(endpoint) || endpoint.chars().any(char::is_whitespace) {
+        return Err(invalid_endpoint(
+            stage,
+            endpoint,
+            "URL schemes, paths, and whitespace are not valid TCP endpoints",
+        ));
+    }
+
+    if endpoint.starts_with('[') {
+        let close = endpoint.find(']').ok_or_else(|| {
+            invalid_endpoint(stage, endpoint, "missing closing bracket for IPv6 host")
+        })?;
+        let host = &endpoint[1..close];
+        if host.is_empty() {
+            return Err(invalid_endpoint(stage, endpoint, "IPv6 host is empty"));
+        }
+        let suffix = &endpoint[close + 1..];
+        let port = if suffix.is_empty() {
+            default_port
+        } else if let Some(port_text) = suffix.strip_prefix(':') {
+            parse_port(port_text, stage, endpoint)?
+        } else {
+            return Err(invalid_endpoint(
+                stage,
+                endpoint,
+                "unexpected text after bracketed IPv6 host",
+            ));
+        };
+        return Ok(ParsedEndpoint {
+            host: host.to_string(),
+            port,
+        });
+    }
+
+    let colon_count = endpoint.chars().filter(|c| *c == ':').count();
+    if colon_count == 0 {
+        return Ok(ParsedEndpoint {
+            host: endpoint.to_string(),
+            port: default_port,
+        });
+    }
+    if colon_count == 1 {
+        let (host, port_text) = endpoint.split_once(':').expect("one colon must split");
+        if host.is_empty() {
+            return Err(invalid_endpoint(stage, endpoint, "host is empty"));
+        }
+        return Ok(ParsedEndpoint {
+            host: host.to_string(),
+            port: parse_port(port_text, stage, endpoint)?,
+        });
+    }
+
+    // An unbracketed multi-colon value is accepted only as a raw IPv6 host;
+    // an explicit IPv6 port must use [addr]:port to remain unambiguous.
+    if std::net::Ipv6Addr::from_str(endpoint).is_ok() {
+        return Ok(ParsedEndpoint {
+            host: endpoint.to_string(),
+            port: default_port,
+        });
+    }
+    Err(invalid_endpoint(
+        stage,
+        endpoint,
+        "IPv6 endpoints with an explicit port must use [addr]:port",
+    ))
+}
+
+fn parse_port(port_text: &str, stage: &str, endpoint: &str) -> io::Result<u16> {
+    let port = port_text.parse::<u16>().map_err(|_| {
+        invalid_endpoint(
+            stage,
+            endpoint,
+            "port must be an integer between 1 and 65535",
+        )
+    })?;
+    validate_port(port, stage, endpoint)
+}
+
+fn validate_port(port: u16, stage: &str, endpoint: &str) -> io::Result<u16> {
+    if port == 0 {
+        return Err(invalid_endpoint(
+            stage,
+            endpoint,
+            "port must be an integer between 1 and 65535",
+        ));
+    }
+    Ok(port)
+}
+
+fn has_uri_or_path(value: &str) -> bool {
+    value.contains("://") || value.contains('/') || value.contains('?') || value.contains('#')
+}
+
+fn invalid_endpoint(stage: &str, endpoint: &str, reason: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("{} endpoint invalid '{}': {}", stage, endpoint, reason),
+    )
+}
+
+fn connect_parsed_endpoint(
+    endpoint: ParsedEndpoint,
+    stage: &str,
+    timeout: Duration,
+) -> io::Result<TcpStream> {
+    let display = format!("{}:{}", endpoint.host, endpoint.port);
+    let candidates: Vec<_> = (endpoint.host.as_str(), endpoint.port)
+        .to_socket_addrs()
+        .map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::AddrNotAvailable,
+                format!(
+                    "{} resolve failed endpoint={} error={}",
+                    stage, display, error
+                ),
+            )
+        })?
+        .collect();
+    if candidates.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            format!(
+                "{} resolve returned no addresses endpoint={}",
+                stage, display
+            ),
+        ));
+    }
+
+    let deadline = Instant::now() + timeout;
+    let mut last_error = None;
+    for address in candidates {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match TcpStream::connect_timeout(&address, remaining) {
+            Ok(stream) => return Ok(stream),
+            Err(error) => last_error = Some((address, error)),
+        }
+    }
+
+    let (address, error) = match last_error {
+        Some(value) => value,
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("{} connect timed out endpoint={}", stage, display),
+            ));
+        }
+    };
+    Err(io::Error::new(
+        error.kind(),
+        format!(
+            "{} connect failed endpoint={} address={} error={}",
+            stage, display, address, error
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_endpoint_supports_hostname_and_explicit_port() {
+        assert_eq!(
+            parse_endpoint("hbbs.example.com:21116", 21117, "test").unwrap(),
+            ParsedEndpoint {
+                host: "hbbs.example.com".to_string(),
+                port: 21116,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_endpoint_supports_bracketed_ipv6() {
+        assert_eq!(
+            parse_endpoint("[::1]:21117", 21116, "test").unwrap(),
+            ParsedEndpoint {
+                host: "::1".to_string(),
+                port: 21117,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_endpoint_supports_raw_ipv6_with_default_port() {
+        assert_eq!(
+            parse_endpoint("2001:db8::1", 21116, "test").unwrap(),
+            ParsedEndpoint {
+                host: "2001:db8::1".to_string(),
+                port: 21116,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_zero_port() {
+        let error = parse_endpoint("hbbs.example.com:0", 21116, "test").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("between 1 and 65535"));
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_url_scheme() {
+        let error = parse_endpoint("https://hbbs.example.com", 21116, "test").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("URL schemes"));
+    }
+}

--- a/rustdesk_ffi/src/protocol/rendezvous.rs
+++ b/rustdesk_ffi/src/protocol/rendezvous.rs
@@ -10,6 +10,7 @@ use super::rendezvous_proto::{
 };
 use super::wire;
 use crate::crypto;
+use crate::net;
 use protobuf::Message;
 use rand::RngCore;
 use std::io;
@@ -64,13 +65,7 @@ impl RendezvousClient {
     ) -> io::Result<()> {
         self.state = RdState::Connecting;
 
-        let addr = format!("{}:{}", host, port);
-        let stream = TcpStream::connect_timeout(
-            &addr
-                .parse()
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
-            Duration::from_secs(10),
-        )?;
+        let stream = net::connect_tcp_host(host, port, "rendezvous", Duration::from_secs(10))?;
 
         stream.set_read_timeout(Some(Duration::from_secs(30)))?;
         stream.set_write_timeout(Some(Duration::from_secs(10)))?;
@@ -333,11 +328,10 @@ impl RendezvousClient {
         server_key: &str,
     ) -> io::Result<TcpStream> {
         let licence_key = server_key.trim();
-        let relay_addr = with_port(relay_server, 21117);
-        let mut stream = TcpStream::connect_timeout(
-            &relay_addr
-                .parse()
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
+        let mut stream = net::connect_tcp_endpoint(
+            relay_server,
+            21117,
+            "relay",
             Duration::from_secs(10),
         )?;
         stream.set_read_timeout(Some(Duration::from_secs(30)))?;
@@ -598,18 +592,6 @@ fn decode_socket_addr(bytes: &[u8]) -> io::Result<SocketAddr> {
     )))
 }
 
-fn with_port(host: &str, default_port: u16) -> String {
-    let trimmed = host.trim();
-    if trimmed.is_empty() {
-        return format!("127.0.0.1:{}", default_port);
-    }
-    if trimmed.starts_with('[') || trimmed.rsplit_once(':').is_some() {
-        trimmed.to_string()
-    } else {
-        format!("{}:{}", trimmed, default_port)
-    }
-}
-
 fn new_relay_uuid() -> String {
     let mut bytes = [0u8; 16];
     rand::thread_rng().fill_bytes(&mut bytes);
@@ -653,6 +635,9 @@ impl Drop for RendezvousClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::ErrorKind;
+    use std::net::TcpListener;
+    use std::thread;
 
     #[test]
     fn test_rendezvous_message_construction() {
@@ -696,5 +681,63 @@ mod tests {
             }
             _ => panic!("wrong oneof variant: {:?}", parsed.union),
         }
+    }
+
+    #[test]
+    fn rendezvous_connect_accepts_hostname_endpoint() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener bind failed");
+        let port = listener
+            .local_addr()
+            .expect("listener address missing")
+            .port();
+        let accept_thread = thread::spawn(move || {
+            let _ = listener
+                .accept()
+                .expect("hostname connection was not accepted");
+        });
+
+        let mut client = RendezvousClient::new();
+        client
+            .connect("localhost", port, "", false)
+            .expect("localhost should resolve and connect");
+        accept_thread.join().expect("accept thread panicked");
+    }
+
+    #[test]
+    fn relay_connect_accepts_hostname_endpoint_with_explicit_port() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener bind failed");
+        let port = listener
+            .local_addr()
+            .expect("listener address missing")
+            .port();
+        let accept_thread = thread::spawn(move || {
+            let (mut stream, _) = listener
+                .accept()
+                .expect("relay connection was not accepted");
+            let payload = wire::read_frame(&mut stream).expect("relay request frame missing");
+            assert!(!payload.is_empty(), "relay request frame should not be empty");
+        });
+
+        let client = RendezvousClient::new();
+        let relay_endpoint = format!("localhost:{}", port);
+        let stream = client
+            .create_relay("peer", "uuid", &relay_endpoint, "")
+            .expect("relay hostname should resolve and connect");
+        drop(stream);
+        accept_thread.join().expect("accept thread panicked");
+    }
+
+    #[test]
+    fn rendezvous_rejects_url_schemes_before_socket_connect() {
+        let mut client = RendezvousClient::new();
+        let error = client
+            .connect("https://localhost", 21116, "", false)
+            .expect_err("URL scheme must not be accepted as a raw endpoint");
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        assert!(
+            error.to_string().contains("scheme") || error.to_string().contains("endpoint"),
+            "error should identify endpoint format: {}",
+            error
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add local HarmonyOS-to-remote Windows RDP file clipboard offer/transfer path with existing 15-file and 2 GiB limits.
- Stabilize RustDesk hostname/DNS resolution across rendezvous, relay, direct, and endpoint parsing.
- Refresh RustDesk relay health-card latency/status immediately after testing.
- Keep READ_PASTEBOARD declaration disabled until an ACL-enabled signing profile is available; clipboard device acceptance remains explicitly blocked and is not claimed as passed.

## Verification
- Native registry/RDP suite: 102 passed, 0 failed.
- RustDesk FFI host suite: 88 passed, 0 failed.
- OHOS RustDesk FFI builds: arm64-v8a and x86_64 rebuilt successfully.
- default@OhosTestCompileArkTS: passed.
- Production assembleHap: BUILD SUCCESSFUL.
- Light open-source compliance gate: passed.
- Device clipboard acceptance: blocked only by signing-profile ACL for ohos.permission.READ_PASTEBOARD (install code 9568289); no other unverified component remains in this change scope.

## Scope note
Two pre-existing untracked user documents under docs/ remain local-only and are not part of this PR.