### PR TITLE
fix(input): preserve remote IME focus session

### DIFF
--- a/entry/src/main/ets/pages/RemoteDesktop.ets
+++ b/entry/src/main/ets/pages/RemoteDesktop.ets
@@ -87,6 +87,7 @@ import {
   resolveRemoteImeDelete,
   resolveRemoteImeSelection,
   shouldAcceptRemoteImeTextChange,
+  shouldCloseRemoteImeSessionOnEditChange,
   shouldRecenterRemoteImeShadow
 } from '../services/RemoteImeSessionPolicy';
 import {
@@ -363,6 +364,7 @@ struct RemoteDesktop {
   private keyboardController: TextAreaController = new TextAreaController();
   private keyboardImeActive: boolean = false;
   private keyboardImeGeneration: number = 0;
+  private keyboardImeEditingObserved: boolean = false;
   private keyboardSyncedCaret: number = REMOTE_IME_CENTER;
   private keyboardExpectedStart: number = -1;
   private keyboardExpectedEnd: number = -1;
@@ -3898,6 +3900,7 @@ struct RemoteDesktop {
     this.keyboardCommandQueue.clear();
     this.keyboardText = shadow.text;
     this.keyboardImeActive = true;
+    this.keyboardImeEditingObserved = false;
     this.keyboardSyncedCaret = shadow.caret;
     this.keyboardExpectedStart = shadow.caret;
     this.keyboardExpectedEnd = shadow.caret;
@@ -3918,6 +3921,7 @@ struct RemoteDesktop {
     }
     this.keyboardImeGeneration++;
     this.keyboardImeActive = false;
+    this.keyboardImeEditingObserved = false;
     this.keyboardCommandQueue.clear();
     this.keyboardText = '';
     this.keyboardSyncedCaret = REMOTE_IME_CENTER;
@@ -3946,6 +3950,7 @@ struct RemoteDesktop {
   }
 
   private handleKeyboardWillInsert(info: InsertValue): boolean {
+    this.keyboardImeEditingObserved = true;
     this.keyboardExpectedStart = info.insertOffset + info.insertValue.length;
     this.keyboardExpectedEnd = this.keyboardExpectedStart;
     return this.keyboardImeActive;
@@ -3961,6 +3966,7 @@ struct RemoteDesktop {
   }
 
   private handleKeyboardWillDelete(info: DeleteValue): boolean {
+    this.keyboardImeEditingObserved = true;
     this.keyboardExpectedStart = info.deleteOffset;
     this.keyboardExpectedEnd = info.deleteOffset;
     return this.keyboardImeActive;
@@ -5222,7 +5228,12 @@ struct RemoteDesktop {
         .id('RemoteDesktopKeyboard')
         .width(1).height(1)
         .opacity(0.01)
+        .fontColor('#00000000')
+        .backgroundColor('#00000000')
+        .caretColor('#00000000')
+        .border({ width: 0 })
         .position({ x: 0, y: 0 })
+        .hitTestBehavior(HitTestMode.Transparent)
         .defaultFocus(false)
         .focusOnTouch(true)
         .enableKeyboardOnFocus(true)
@@ -5247,7 +5258,12 @@ struct RemoteDesktop {
         .onEditChange((isEditing: boolean): void => {
           hilog.info(RD_DOMAIN, RD_TAG, 'kbd-editing=' + (isEditing ? 'true' : 'false') +
             ' open=' + (this.keyboardOpen ? 'true' : 'false'));
-          if (!isEditing && this.keyboardOpen) {
+          if (isEditing) {
+            this.keyboardImeEditingObserved = true;
+            return;
+          }
+          if (shouldCloseRemoteImeSessionOnEditChange(
+            this.keyboardOpen, isEditing, this.keyboardImeEditingObserved)) {
             if (this.keyboardSubmitRefocusPending || this.keepKeyboardAfterSheetClose) {
               hilog.info(RD_DOMAIN, RD_TAG, 'kbd-editing-close ignored: refocus pending');
               return;

--- a/entry/src/main/ets/services/RemoteImeSessionPolicy.ets
+++ b/entry/src/main/ets/services/RemoteImeSessionPolicy.ets
@@ -168,6 +168,14 @@ export function shouldAcceptRemoteImeTextChange(active: boolean, previewTextLeng
   return active && previewTextLength === 0;
 }
 
+export function shouldCloseRemoteImeSessionOnEditChange(
+  keyboardOpen: boolean,
+  isEditing: boolean,
+  editingObserved: boolean
+): boolean {
+  return keyboardOpen && !isEditing && editingObserved;
+}
+
 export function createRemoteImeDiagnostic(
   source: string,
   units: number,

--- a/entry/src/ohosTest/ets/test/RemoteImeSessionPolicy.test.ets
+++ b/entry/src/ohosTest/ets/test/RemoteImeSessionPolicy.test.ets
@@ -11,6 +11,7 @@ import {
   resolveRemoteImeDelete,
   resolveRemoteImeSelection,
   shouldAcceptRemoteImeTextChange,
+  shouldCloseRemoteImeSessionOnEditChange,
   shouldRecenterRemoteImeShadow,
   splitRemoteImeCaretMovement
 } from '../../../main/ets/services/RemoteImeSessionPolicy';
@@ -31,6 +32,13 @@ export default function remoteImeSessionPolicyTest(): void {
       expect(shouldAcceptRemoteImeTextChange(true, 4)).assertFalse();
       expect(shouldAcceptRemoteImeTextChange(true, 0)).assertTrue();
       expect(shouldAcceptRemoteImeTextChange(false, 0)).assertFalse();
+    });
+
+    it('keeps_session_open_for_initial_editing_false_transition', 0, (): void => {
+      expect(shouldCloseRemoteImeSessionOnEditChange(true, false, false)).assertFalse();
+      expect(shouldCloseRemoteImeSessionOnEditChange(true, false, true)).assertTrue();
+      expect(shouldCloseRemoteImeSessionOnEditChange(true, true, false)).assertFalse();
+      expect(shouldCloseRemoteImeSessionOnEditChange(false, false, true)).assertFalse();
     });
 
     it('ignores_expected_and_programmatic_selection', 0, (): void => {


### PR DESCRIPTION
## Root cause
- the hidden TextArea can emit onEditChange(false) during the initial IME/focus transition
- the previous handler treated that transient event as a real close, set keyboardImeActive=false, and onWillInsert then rejected every key
- the native caret/selection handle was also visible because opacity alone does not hide caret styling

## Fix
- ignore the initial editing=false transition until editing has been observed
- keep explicit close and post-edit focus loss behavior
- make hidden editor text, background, caret/handle and hit area transparent
- add regression tests for the session state policy

## Verification
- RED test reproduced missing production policy export
- ohosTest ArkTS compile passed
- default@OhosTestCompileArkTS passed
- assembleHap passed
- Light compliance passed
- signed HAP installed and launched on emulator
- full onDeviceTest still stops at existing GenerateDeviceCoverage connect-key environment gate

Real authenticated RDP/RustDesk typing acceptance remains to be performed on target hardware.