### PR TITLE
docs(codex): record Mac final verification

### DIFF
--- a/docs/codex/CURRENT.md
+++ b/docs/codex/CURRENT.md
@@ -6,16 +6,16 @@ Updated: 2026-07-23 Asia/Shanghai
 
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
 - Public branch: `main`
-- Public main commit: `c502221e3` (`Merge PR #28: refresh shared handoff state`)
-- Active task: `codex/mac-migration-bootstrap`; the migration adapter commit is
-  `ffbd1f5`.
-- Local `main` equals local `origin/main`; the task branch is based directly on that
-  public commit.
+- Public main commit: `4dbd5d928` (`Merge pull request #29 from Mydstiny/codex/mac-migration-bootstrap`)
+- Active task: `codex/mac-final-verification`.
+- Local `main` equals local `origin/main`; the active task branch is based directly
+  on that public commit.
 
 ## Current phase
 
 - The migration package restored the complete public source, Git history and
-  recursive `freerdp` submodule on macOS.
+  recursive `freerdp` submodule on macOS; the bootstrap changes are now merged to
+  public `main`.
 - DevEco Studio 6.1.1 opens the repository root successfully. The project remains
   `runtimeOS: HarmonyOS` with `targetSdkVersion` and `compatibleSdkVersion`
   `6.1.0(23)`.
@@ -40,30 +40,34 @@ Updated: 2026-07-23 Asia/Shanghai
 - Opus and RustDesk FFI dependencies build successfully for both `arm64-v8a` and
   `x86_64`; the FFI symbol checks pass after fixing the `pipefail`/SIGPIPE false
   failure in the migration script.
+- `default@OhosTestCompileArkTS` passes. The non-daemon `assembleHap` build passes
+  through native Ninja, ArkTS, `PackageHap`, `PackingCheck`, `SignHap` and debug
+  symbol collection with the Mac-local private signing profile.
 - `hvigorw tasks`, `hvigorw init`, native CMake/Ninja and ArkTS compilation pass.
-  `assembleHap` reaches `PackageHap` and `PackingCheck`, producing the local
-  unsigned artifact at `entry/build/default/outputs/default/entry-default-unsigned.hap`.
+  The local build produces both unsigned and signed HAP artifacts; neither is
+  tracked or uploaded.
 - `core.hooksPath=.githooks`, the sync workflow, history guard, FreeRDP provenance
   checks and Light compliance checks were validated on the restored workspace.
 
 ## Blockers
 
-- GitHub fetch/push/PR operations need a networked run; the current environment has
-  intermittent DNS/SSL failures for `github.com`.
-- A signed HAP requires private local signing material and matching values in the
-  ignored `build-profile.json5`: `.p12`, `.p7b`, `.cer`, store/key passwords and
-  alias. These must be transferred through a secure channel and never committed.
-- AGConnect is optional for import/build but cloud features require the local
-  ignored `entry/src/main/resources/rawfile/agconnect-services.json`; never place
-  its secrets in shared docs or Git.
-- The local PowerShell fallback works for repository checks, but a stable system
-  PowerShell 7 install remains preferable. API 23 native SDK and Rust targets are
-  already present on this Mac.
+- GitHub fetch/push/PR operations require network access outside the local sandbox;
+  the post-merge sync has now succeeded.
+- No SDK or signing input remains required for the current local build: DevEco,
+  API 23 native tooling, Rust targets and the private signing profile are present
+  on this Mac. Signing files and passwords remain local-only.
+- AGConnect is optional for import/build and is not currently configured; provide
+  `entry/src/main/resources/rawfile/agconnect-services.json` through a secure
+  channel only if cloud features or cloud-device validation are needed.
+- The repository-local PowerShell 7 fallback (`7.7.0-preview.3`) passes the
+  compliance gate; a stable system PowerShell 7 install is still recommended but
+  is not blocking this workspace.
 
 ## Next
 
-- Run the final post-commit checks and push `codex/mac-migration-bootstrap`.
-- Create the PR, wait for `open-source-compliance`, merge with a merge commit, then
-  fast-forward local `main` and delete the merged task branch.
+- Run the full API 23 post-merge verification and record exact results.
+- Update the shared handoff, push `codex/mac-final-verification`, and create its PR.
+- Wait for `open-source-compliance`, merge with a merge commit, then fast-forward
+  local `main` and delete the merged task branch.
 - Configure private signing/AGConnect values locally if signed or cloud-enabled
   device validation is required; keep device data and raw evidence local-only.

--- a/docs/codex/HANDOFF.md
+++ b/docs/codex/HANDOFF.md
@@ -4,15 +4,16 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Source
 
-- Base: `main` at `c502221e3`, restored from the migration package
-- Active task branch: `codex/mac-migration-bootstrap`
-- Migration adapter commit: `ffbd1f5`
+- Base: `main` at `4dbd5d928`, restored from the migration package and merged
+  through PR #29
+- Active task branch: `codex/mac-final-verification`
 - FreeRDP submodule: `dae8276ac7361b8d14f7b87d41163fe03dbb944e`
 
 ## Completed
 
 - Complete public source and Git history were restored from the migration bundle;
-  the recursive FreeRDP submodule is initialized.
+  the recursive FreeRDP submodule is initialized, and the bootstrap changes are
+  merged to public `main`.
 - DevEco Studio 6.1.1 opens the repository root. API 23 remains the project
   baseline, with the full HarmonyOS SDK and standalone API 23 native SDK kept in
   separate local properties.
@@ -27,30 +28,31 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Verification
 
-- `sync_workspace.sh status` and `doctor` passed on the restored clean `main`
-  checkout before the task branch was created.
+- The post-merge `sync_workspace.sh sync` and task-start gate passed. The final
+  verification run is active on `codex/mac-final-verification`.
 - `hvigorw tasks` and `hvigorw init` passed.
 - Opus and RustDesk FFI builds passed for `arm64-v8a` and `x86_64`.
-- `assembleHap --no-daemon` passed through ArkTS, CMake/Ninja, native strip,
-  `PackageHap` and `PackingCheck`; `SignHap` stops on the placeholder certificate
-  path in the ignored local profile.
+- `default@OhosTestCompileArkTS` passed. `assembleHap --no-daemon` passed through
+  ArkTS, CMake/Ninja, native strip, `PackageHap`, `PackingCheck`, `SignHap` and
+  debug symbol collection using the Mac-local private signing profile.
 - Shell syntax, workflow policy, pre-push history protection, FreeRDP provenance,
   and Light compliance checks pass on macOS, including the repository-local
   PowerShell wrapper when no shell setup is sourced first.
 
-## Private inputs still local
+## Private input status
 
-- Signed builds: `.p12`, `.p7b`, `.cer`, certificate alias and passwords, configured
-  only in the ignored `build-profile.json5`.
-- Cloud features: local
-  `entry/src/main/resources/rawfile/agconnect-services.json` with its secret fields.
+- Signed builds: the private profile is already configured locally and `SignHap`
+  passed. The `.p12`, `.p7b`, `.cer`, alias and passwords remain outside Git and
+  shared memory.
+- Cloud features: `entry/src/main/resources/rawfile/agconnect-services.json` is
+  not present on this Mac; provide it securely only when cloud features are needed.
 - Real-device authorization, logs, screenshots and user data stay on the device or
   local machine and are not part of the migration handoff.
 
 ## Next owner action
 
-1. Run the final post-commit checks and inspect the clean working tree.
-2. Push only `codex/mac-migration-bootstrap` and create a PR.
+1. Run the final API 23 checks and inspect the clean working tree.
+2. Push only `codex/mac-final-verification` and create a PR.
 3. Wait for `open-source-compliance`, merge without squash, then run `main` sync and
    delete the merged branch.
 4. Report the final Mac commit/branch, `main` equality, submodule, hook, PowerShell,

--- a/docs/codex/QUEUE.md
+++ b/docs/codex/QUEUE.md
@@ -4,8 +4,9 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Now
 
-- Finish `codex/mac-migration-bootstrap`: run the final checks, commit the scoped
-  migration fixes, push the task branch and create its PR.
+- Finish `codex/mac-final-verification`: API 23 checks and Light compliance are
+  complete; commit the scoped shared-state update, push the branch and create its
+  PR.
 - Wait for `open-source-compliance`; merge with a merge commit, then synchronize
   local `main` and remove the merged task branch.
 


### PR DESCRIPTION
## Summary
- Refresh the sanitized docs/codex shared state from merged main at 4dbd5d928.
- Record the Mac API 23, DevEco Studio, Git workflow and private-configuration status.
- Record the final ArkTS, dual-ABI Opus/RustDesk FFI, signed HAP and Light compliance results.

## Scope
- Documentation only: docs/codex/CURRENT.md, docs/codex/QUEUE.md, docs/codex/HANDOFF.md.
- No runtime code, SDKs, build caches, HAP artifacts, secrets, logs or user data are included.

## Private configuration
- The Mac-local signing profile is working and remains untracked.
- AGConnect configuration is optional and is not present on this Mac.

## Merge
- Wait for open-source-compliance.
- Merge with a merge commit; do not squash.