### PR TITLE
docs(codex): close migration handoff

### DIFF
--- a/docs/codex/CURRENT.md
+++ b/docs/codex/CURRENT.md
@@ -6,16 +6,16 @@ Updated: 2026-07-23 Asia/Shanghai
 
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
 - Public branch: `main`
-- Public main commit: `4dbd5d928` (`Merge pull request #29 from Mydstiny/codex/mac-migration-bootstrap`)
-- Active task: `codex/mac-final-verification`.
-- Local `main` equals local `origin/main`; the active task branch is based directly
-  on that public commit.
+- Last migration merge commit: `e7dfb3a85` (`Merge pull request #30 from Mydstiny/codex/mac-final-verification`)
+- Active task: none; the macOS migration and final verification are complete.
+- Local `main` equals local `origin/main`; the closeout branch only publishes this
+  final shared-state update.
 
 ## Current phase
 
 - The migration package restored the complete public source, Git history and
-  recursive `freerdp` submodule on macOS; the bootstrap changes are now merged to
-  public `main`.
+  recursive `freerdp` submodule on macOS; the bootstrap and final verification
+  records are merged to public `main` through PRs #29 and #30.
 - DevEco Studio 6.1.1 opens the repository root successfully. The project remains
   `runtimeOS: HarmonyOS` with `targetSdkVersion` and `compatibleSdkVersion`
   `6.1.0(23)`.
@@ -51,8 +51,6 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Blockers
 
-- GitHub fetch/push/PR operations require network access outside the local sandbox;
-  the post-merge sync has now succeeded.
 - No SDK or signing input remains required for the current local build: DevEco,
   API 23 native tooling, Rust targets and the private signing profile are present
   on this Mac. Signing files and passwords remain local-only.
@@ -65,9 +63,8 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Next
 
-- Run the full API 23 post-merge verification and record exact results.
-- Update the shared handoff, push `codex/mac-final-verification`, and create its PR.
-- Wait for `open-source-compliance`, merge with a merge commit, then fast-forward
-  local `main` and delete the merged task branch.
-- Configure private signing/AGConnect values locally if signed or cloud-enabled
-  device validation is required; keep device data and raw evidence local-only.
+- On a clean Windows clone, run the shared-state, submodule and history gates.
+- Configure AGConnect locally only if cloud features or cloud-device validation are
+  needed; keep device data and raw evidence local-only.
+- Complete real-device acceptance for RDP, RustDesk, SSH/SFTP, VNC, PIP/live-view
+  and cloud-sync checkpoints.

--- a/docs/codex/HANDOFF.md
+++ b/docs/codex/HANDOFF.md
@@ -4,16 +4,15 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Source
 
-- Base: `main` at `4dbd5d928`, restored from the migration package and merged
-  through PR #29
-- Active task branch: `codex/mac-final-verification`
+- Migration baseline: `main` at `e7dfb3a85`, with PR #30 merged using a merge commit
+- Active task branch: none
 - FreeRDP submodule: `dae8276ac7361b8d14f7b87d41163fe03dbb944e`
 
 ## Completed
 
 - Complete public source and Git history were restored from the migration bundle;
-  the recursive FreeRDP submodule is initialized, and the bootstrap changes are
-  merged to public `main`.
+  the recursive FreeRDP submodule is initialized, and the bootstrap plus final
+  verification state are merged to public `main`.
 - DevEco Studio 6.1.1 opens the repository root. API 23 remains the project
   baseline, with the full HarmonyOS SDK and standalone API 23 native SDK kept in
   separate local properties.
@@ -28,8 +27,9 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Verification
 
-- The post-merge `sync_workspace.sh sync` and task-start gate passed. The final
-  verification run is active on `codex/mac-final-verification`.
+- The post-merge `sync_workspace.sh sync`, task-start gate and final
+  `sync_workspace.sh status`/`doctor` checks passed. `main` is synchronized at
+  `e7dfb3a85`, and no task branch remains.
 - `hvigorw tasks` and `hvigorw init` passed.
 - Opus and RustDesk FFI builds passed for `arm64-v8a` and `x86_64`.
 - `default@OhosTestCompileArkTS` passed. `assembleHap --no-daemon` passed through
@@ -51,9 +51,6 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Next owner action
 
-1. Run the final API 23 checks and inspect the clean working tree.
-2. Push only `codex/mac-final-verification` and create a PR.
-3. Wait for `open-source-compliance`, merge without squash, then run `main` sync and
-   delete the merged branch.
-4. Report the final Mac commit/branch, `main` equality, submodule, hook, PowerShell,
-   sync-script, clean-worktree and private-input status.
+1. Start the next independent task only from `main` after `sync_workspace.sh sync`.
+2. Configure AGConnect locally only if cloud features are required.
+3. Complete the remaining real-device protocol and cloud-sync acceptance matrix.

--- a/docs/codex/QUEUE.md
+++ b/docs/codex/QUEUE.md
@@ -4,15 +4,11 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Now
 
-- Finish `codex/mac-final-verification`: API 23 checks and Light compliance are
-  complete; commit the scoped shared-state update, push the branch and create its
-  PR.
-- Wait for `open-source-compliance`; merge with a merge commit, then synchronize
-  local `main` and remove the merged task branch.
+- No active migration task. The macOS workspace is synchronized and ready for the
+  next independent task.
 
 ## Next
 
-- On a networked Mac, verify fetch, push and PR operations against GitHub.
 - On a clean Windows clone, run the same shared-state, submodule and history gates.
 - Configure private signing and optional AGConnect files only on the machine that
   needs signed or cloud-enabled builds.


### PR DESCRIPTION
## Summary
- Mark the macOS migration and final verification complete in the sanitized shared state.
- Remove stale active-branch and pending-merge instructions after PR #30.
- Keep the remaining Windows gate, optional AGConnect setup and real-device acceptance as the next work.

## Scope
- Documentation only: docs/codex/CURRENT.md, docs/codex/QUEUE.md, docs/codex/HANDOFF.md.
- No runtime code, SDKs, build caches, HAP artifacts, secrets, logs or user data.

## Merge
- Wait for open-source-compliance.
- Merge with a merge commit; do not squash.