### PR TITLE
fix(workflow): expose macOS hdc toolchain

### DIFF
--- a/docs/codex/CURRENT.md
+++ b/docs/codex/CURRENT.md
@@ -6,10 +6,11 @@ Updated: 2026-07-23 Asia/Shanghai
 
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
 - Public branch: `main`
-- Last migration merge commit: `e7dfb3a85` (`Merge pull request #30 from Mydstiny/codex/mac-final-verification`)
-- Active task: none; the macOS migration and final verification are complete.
-- Local `main` equals local `origin/main`; the closeout branch only publishes this
-  final shared-state update.
+- Last migration merge commit: `b71639512` (`Merge pull request #31 from Mydstiny/codex/close-migration-handoff`)
+- Active task: none; the completed Mac `hdc` toolchain fix is included in this
+  handoff and must be published through the normal PR merge flow.
+- Local `main` equals local `origin/main`; the scoped publication branch is based
+  directly on that public commit.
 
 ## Current phase
 
@@ -21,6 +22,9 @@ Updated: 2026-07-23 Asia/Shanghai
   `6.1.0(23)`.
 - Cross-device memory is the sanitized content under `docs/codex/`; no Windows or
   Mac Codex raw memory directory is copied or used as shared state.
+- Both the full DevEco SDK and standalone API 23 SDK contain executable arm64
+  `hdc` binaries. `scripts/macos_env.sh` now adds the full HarmonyOS SDK
+  `toolchains` first and the standalone API 23 `toolchains` as a fallback.
 
 ## Completed verification
 
@@ -34,7 +38,7 @@ Updated: 2026-07-23 Asia/Shanghai
   - Standalone OpenHarmony API 23 native SDK:
     `/Users/mydestiny/Library/OpenHarmony/Sdk/23`
 - `scripts/macos_env.sh` detects DevEco Node/Hvigor/ohpm, the bundled JBR/Java,
-  OHOS LLVM/CMake/Ninja, Rust/Cargo and the local PowerShell fallback.
+  OHOS LLVM/CMake/Ninja, Rust/Cargo, `hdc` and the local PowerShell fallback.
 - API 23 Rust targets are installed:
   `aarch64-unknown-linux-ohos` and `x86_64-unknown-linux-ohos`.
 - Opus and RustDesk FFI dependencies build successfully for both `arm64-v8a` and
@@ -48,6 +52,9 @@ Updated: 2026-07-23 Asia/Shanghai
   tracked or uploaded.
 - `core.hooksPath=.githooks`, the sync workflow, history guard, FreeRDP provenance
   checks and Light compliance checks were validated on the restored workspace.
+- After `source scripts/macos_env.sh`, `hdc --version` resolves to DevEco hdc
+  `3.2.0d`. `hdc start` succeeds; `hdc list targets` reports `[Empty]` because no
+  HarmonyOS device or emulator is currently connected and authorized.
 
 ## Blockers
 
@@ -57,6 +64,8 @@ Updated: 2026-07-23 Asia/Shanghai
 - AGConnect is optional for import/build and is not currently configured; provide
   `entry/src/main/resources/rawfile/agconnect-services.json` through a secure
   channel only if cloud features or cloud-device validation are needed.
+- Device validation remains pending until a HarmonyOS device or emulator is
+  connected and authorized for `hdc`.
 - The repository-local PowerShell 7 fallback (`7.7.0-preview.3`) passes the
   compliance gate; a stable system PowerShell 7 install is still recommended but
   is not blocking this workspace.

--- a/docs/codex/DECISIONS.md
+++ b/docs/codex/DECISIONS.md
@@ -34,3 +34,21 @@ Large static archives must not be validated with `nm | grep -q` or an equivalent
 early-closing consumer under `set -o pipefail`. Use a full-stream grep redirected
 to `/dev/null`, or a temporary symbol list, so a successful match cannot be
 reported as `nm` exit 141.
+
+## D-008 - macOS `hdc` comes from SDK `toolchains`
+
+DevEco's `hdc` executable is shipped under the SDK `toolchains` directory, not
+the application-level `tools` directory. `scripts/macos_env.sh` puts the full
+HarmonyOS SDK toolchain first and the standalone API 23 toolchain second. A Mac
+CLI session must source the script before using `hdc`:
+
+```sh
+source scripts/macos_env.sh
+hdc --version
+hdc start
+hdc list targets
+```
+
+If the command resolves and the server starts but the target list is `[Empty]`,
+the toolchain is working and no HarmonyOS device or emulator is connected and
+authorized yet.

--- a/docs/codex/HANDOFF.md
+++ b/docs/codex/HANDOFF.md
@@ -4,8 +4,8 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Source
 
-- Migration baseline: `main` at `e7dfb3a85`, with PR #30 merged using a merge commit
-- Active task branch: none
+- Migration baseline: `main` at `b71639512`, with PR #31 merged using a merge commit
+- Active task branch: none; the completed Mac `hdc` PATH fix is ready for PR publication
 - FreeRDP submodule: `dae8276ac7361b8d14f7b87d41163fe03dbb944e`
 
 ## Completed
@@ -20,16 +20,21 @@ Updated: 2026-07-23 Asia/Shanghai
   configure OHOS clang/Cargo linkers and build both RustDesk FFI ABIs.
 - The FFI migration script's `nm | grep -Eq` SIGPIPE false failure was fixed;
   both architecture symbol checks now pass.
-- `assembleHap` reaches packaging and creates an unsigned HAP. Signing is the only
-  remaining build-stage requirement and is intentionally local-only.
+- `assembleHap --no-daemon` passed through packaging, signing and debug symbol
+  collection with the Mac-local private signing profile. Signing files remain
+  local-only.
+- `scripts/macos_env.sh` now exposes the DevEco/native SDK `hdc` toolchain. After
+  sourcing it, `hdc --version` reports `3.2.0d`; `hdc start` succeeds and
+  `hdc list targets` reports `[Empty]` only because no device is connected or
+  authorized.
 - `AGENTS.md` now directs both platforms to the sanitized `docs/codex/` state and
   explicitly forbids sharing raw Codex memory directories.
 
 ## Verification
 
 - The post-merge `sync_workspace.sh sync`, task-start gate and final
-  `sync_workspace.sh status`/`doctor` checks passed. `main` is synchronized at
-  `e7dfb3a85`, and no task branch remains.
+  `sync_workspace.sh status`/`doctor` checks passed. The hdc PATH fix was
+  verified on macOS.
 - `hvigorw tasks` and `hvigorw init` passed.
 - Opus and RustDesk FFI builds passed for `arm64-v8a` and `x86_64`.
 - `default@OhosTestCompileArkTS` passed. `assembleHap --no-daemon` passed through
@@ -51,6 +56,7 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Next owner action
 
-1. Start the next independent task only from `main` after `sync_workspace.sh sync`.
-2. Configure AGConnect locally only if cloud features are required.
-3. Complete the remaining real-device protocol and cloud-sync acceptance matrix.
+1. After the hdc PR is merged, start Windows from synchronized `main` and run the
+   shared-state, submodule and history gates.
+2. Configure AGConnect locally only if cloud features are required, then complete
+   the remaining real-device protocol and cloud-sync acceptance matrix.

--- a/docs/codex/QUEUE.md
+++ b/docs/codex/QUEUE.md
@@ -4,8 +4,8 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Now
 
-- No active migration task. The macOS workspace is synchronized and ready for the
-  next independent task.
+- No active migration task. The Mac `hdc` PATH fix is verified and ready for the
+  normal PR and merge flow; the next device starts from the merged `main`.
 
 ## Next
 

--- a/scripts/macos_env.sh
+++ b/scripts/macos_env.sh
@@ -52,6 +52,13 @@ fi
 prepend_path "$deveco_root/tools/node/bin"
 prepend_path "$deveco_root/tools/hvigor/bin"
 prepend_path "$deveco_root/tools/ohpm/bin"
+# DevEco's hdc is shipped in the SDK toolchains directory, not in the
+# application-level tools directory. Prefer the full HarmonyOS SDK hdc used by
+# DevEco, while keeping the standalone API 23 toolchain available as a fallback.
+harmonyos_toolchains="$harmonyos_sdk_root/default/openharmony/toolchains"
+ohos_toolchains="$ohos_sdk_root/toolchains"
+prepend_path "$ohos_toolchains"
+prepend_path "$harmonyos_toolchains"
 prepend_path "$ohos_native/llvm/bin"
 prepend_path "$ohos_native/build-tools/cmake/bin"
 export CC_aarch64_unknown_linux_ohos="$ohos_native/llvm/bin/clang"
@@ -92,6 +99,8 @@ printf 'Mac toolchain environment: node=%s hvigorw=%s ohpm=%s\n' \
     "$(command -v node 2>/dev/null || printf '%s' unavailable)" \
     "$(command -v hvigorw 2>/dev/null || printf '%s' unavailable)" \
     "$(command -v ohpm 2>/dev/null || printf '%s' unavailable)"
+printf 'Mac toolchain environment: hdc=%s\n' \
+    "$(command -v hdc 2>/dev/null || printf '%s' unavailable)"
 printf 'Mac toolchain environment: java=%s JAVA_HOME=%s\n' \
     "$(command -v java 2>/dev/null || printf '%s' unavailable)" \
     "${JAVA_HOME:-unset}"


### PR DESCRIPTION
Summary:
- Add the DevEco and standalone API 23 SDK toolchains directories to the macOS environment PATH, with the full HarmonyOS SDK preferred.
- Record the hdc diagnosis and sanitized cross-device handoff state.

Verification:
- Opus and RustDesk FFI builds passed for arm64-v8a and x86_64.
- assembleHap --no-daemon passed through SignHap with the local signing profile.
- Light open-source compliance, finish-check, shell syntax, and diff checks passed.
- hdc 3.2.0d starts successfully; list targets is [Empty] because no device is connected or authorized.

No runtime code was changed. Please merge with a merge commit after open-source-compliance passes.