### PR TITLE
docs(workflow): close hdc handoff state

### DIFF
--- a/docs/codex/CURRENT.md
+++ b/docs/codex/CURRENT.md
@@ -6,11 +6,10 @@ Updated: 2026-07-23 Asia/Shanghai
 
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
 - Public branch: `main`
-- Last migration merge commit: `b71639512` (`Merge pull request #31 from Mydstiny/codex/close-migration-handoff`)
-- Active task: none; the completed Mac `hdc` toolchain fix is included in this
-  handoff and must be published through the normal PR merge flow.
-- Local `main` equals local `origin/main`; the scoped publication branch is based
-  directly on that public commit.
+- Last migration merge commit: `dc715d230` (PR #32, merged with a merge commit)
+- Active task: none; the completed Mac `hdc` toolchain fix is already merged.
+- Shared state is synchronized with public `main`; the next device must sync before
+  starting an independent task.
 
 ## Current phase
 

--- a/docs/codex/HANDOFF.md
+++ b/docs/codex/HANDOFF.md
@@ -4,8 +4,8 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Source
 
-- Migration baseline: `main` at `b71639512`, with PR #31 merged using a merge commit
-- Active task branch: none; the completed Mac `hdc` PATH fix is ready for PR publication
+- Migration baseline: `main` at `dc715d230`, with PR #32 merged using a merge commit
+- Active task branch: none
 - FreeRDP submodule: `dae8276ac7361b8d14f7b87d41163fe03dbb944e`
 
 ## Completed
@@ -56,7 +56,7 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Next owner action
 
-1. After the hdc PR is merged, start Windows from synchronized `main` and run the
-   shared-state, submodule and history gates.
+1. Start Windows from synchronized `main` and run the shared-state, submodule and
+   history gates.
 2. Configure AGConnect locally only if cloud features are required, then complete
    the remaining real-device protocol and cloud-sync acceptance matrix.

--- a/docs/codex/QUEUE.md
+++ b/docs/codex/QUEUE.md
@@ -4,8 +4,8 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Now
 
-- No active migration task. The Mac `hdc` PATH fix is verified and ready for the
-  normal PR and merge flow; the next device starts from the merged `main`.
+- No active migration task. The Mac `hdc` PATH fix is verified and merged through
+  PR #32; the next device starts from synchronized `main`.
 
 ## Next
 


### PR DESCRIPTION
This documentation-only follow-up updates the shared CURRENT, QUEUE, and HANDOFF records after PR #32 was merged. It records the merged commit and removes stale pending-publication wording.

Verification: finish-check and the Light open-source compliance gate passed. Merge with a merge commit.