### PR TITLE
docs(workflow): refresh handoff commit

### DIFF
--- a/docs/codex/CURRENT.md
+++ b/docs/codex/CURRENT.md
@@ -6,7 +6,8 @@ Updated: 2026-07-23 Asia/Shanghai
 
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
 - Public branch: `main`
-- Last migration merge commit: `dc715d230` (PR #32, merged with a merge commit)
+- Current public `main`: `e9ea4f541` (PR #33, merged with a merge commit)
+- Last workflow change: `dc715d230` (PR #32, merged with a merge commit)
 - Active task: none; the completed Mac `hdc` toolchain fix is already merged.
 - Shared state is synchronized with public `main`; the next device must sync before
   starting an independent task.

--- a/docs/codex/HANDOFF.md
+++ b/docs/codex/HANDOFF.md
@@ -4,7 +4,8 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Source
 
-- Migration baseline: `main` at `dc715d230`, with PR #32 merged using a merge commit
+- Current public `main`: `e9ea4f541`, with PR #33 merged using a merge commit
+- Mac hdc workflow fix: `dc715d230`, with PR #32 merged using a merge commit
 - Active task branch: none
 - FreeRDP submodule: `dae8276ac7361b8d14f7b87d41163fe03dbb944e`
 


### PR DESCRIPTION
Update the sanitized CURRENT and HANDOFF records to reference the current public main after PR #33 and the hdc workflow fix from PR #32.

Verification: finish-check and Light open-source compliance passed. Merge with a merge commit.