### PR TITLE
docs(codex): record Windows development handoff

### DIFF
--- a/docs/codex/CURRENT.md
+++ b/docs/codex/CURRENT.md
@@ -6,25 +6,57 @@ Updated: 2026-07-23 Asia/Shanghai
 
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
 - Public branch: `main`
-- Public main commit at last sync: `c5347f141` (`Merge PR #27: restore complete diagnostics history and collaboration workflow`)
-- Canonical development model: one local workspace, one active `codex/<task>` branch, protected PR merge.
+- Public main commit at audit start: `c502221e3` (`Merge PR #28: refresh shared handoff state`)
+- Audit branch: `codex/windows-memory-sanitize`, based on synchronized `main`
+- No unfinished local `codex/...` branch existed before this audit.
+- The workspace contains user-owned test edits, logs, screenshots, XML and native build evidence. They remain local and are not part of this task.
 
 ## Current phase
 
-- Cross-device collaboration bootstrap is merged and available on `main`; Windows and macOS share source, sanitized task state and the same start-of-task synchronization gate.
-- The 1.0.8 runtime, cloud-sync protection, onboarding and PIP/RDP lifecycle changes are in public history; device acceptance remains a separate validation item.
+- Windows Codex memory sanitization and cross-device development handoff audit.
+- No runtime, ArkTS, C/C++, Rust, FreeRDP, dependency or signing configuration was changed.
+- The normal `start` command could not be used because the working tree is intentionally dirty with user evidence. The branch was created directly from synchronized `main`; only the four `docs/codex` files are in scope.
 
-## Completed verification recorded in public history
+## Windows evidence collected in this audit
 
-- Native and RustDesk FFI test suites passed for the published runtime checkpoints.
-- `default@OhosTestCompileArkTS`, production HAP build, `git diff --check` and Light open-source compliance passed for the published runtime checkpoints.
+| Item | Result | Scope |
+| --- | --- | --- |
+| DevEco Studio | `6.1.1.280` installation metadata | Windows verified |
+| HarmonyOS target | API 23, `targetSdkVersion`/`compatibleSdkVersion` `6.1.0(23)` | Repository configuration verified |
+| Runtime and module | `runtimeOS: HarmonyOS`, product `default`, module `entry` | Repository configuration verified |
+| DevEco bundled Node | `18.20.1` | Windows verified |
+| Hvigor CLI | `6.24.2` | Windows verified |
+| ohpm | `6.1.2.268` | Windows verified |
+| CMake / Ninja | `3.29.2` / `1.12.0` | Windows verified |
+| OHOS LLVM/Clang | `15.0.4` | Windows verified |
+| Rust / Cargo | `1.96.0` / `1.96.0` | Windows verified |
+| Rust OHOS targets | `aarch64-unknown-linux-ohos`, `x86_64-unknown-linux-ohos` | Windows verified |
+| Windows PowerShell | `5.1.26100.8875`; `pwsh` is not installed | Windows verified |
+| API 23 reference docs | Local copy is present | Windows verified; content stays local |
+
+The old baseline's Node 24 and approximate DevEco 26.0 entries are historical and are not current Windows facts. Mac tool versions and SDK installation remain unverified.
+
+## Audit result
+
+- Shared docs previously pointed at `c5347f141`; the actual synchronized `main` and `origin/main` are `c502221e3`.
+- `scripts/macos_env.sh`, `scripts/resolve_ohos_sdk.sh` and `scripts/resolve_powershell.sh` are not present. They are migration documentation gaps, not permission to invent or add runtime scripts in this task.
+- The repository already contains the cross-device workflow, migration bundle generator, public Git history, submodule pointer and sanitized state files.
+- Windows Codex memory contains useful technical conclusions about API 23, ArkTS strict mode, bindSheet mounting, OHOS C++/Crypto APIs, RustDesk stream framing/control consumption and Git safety. These conclusions are summarized in `DECISIONS.md` and `HANDOFF.md`; raw memory is not copied.
+
+## Verification status
+
+- `git status --short --branch`: confirmed `main` was synchronized before branch creation and showed only user-owned local material outside this task.
+- `git log`: confirmed `c502221e3` is the current public merge tip.
+- Direct tool checks confirmed the Windows versions listed above.
+- The recorded public runtime checkpoints include native/RustDesk tests, `default@OhosTestCompileArkTS`, production `assembleHap`, `git diff --check` and Light compliance. Those records are not a substitute for new Mac or real-device verification.
+- This audit branch still requires the final document diff check, Light gate, DCO commit, push, PR check and merge workflow.
 
 ## Next
 
-- Verify the cross-device synchronization gate on a clean Windows clone and a clean macOS clone.
-- On an unlocked HarmonyOS target, complete the remaining PIP, live-view, cloud-sync and first-install acceptance matrix.
-- Keep all raw device evidence and private build inputs local-only.
+- Finish and publish the four sanitized handoff documents from `codex/windows-memory-sanitize`.
+- After PR merge, have macOS sync the merged `main`, configure machine-local SDK/toolchains/private files, and run the clean-clone workflow.
+- Complete real-device acceptance for PIP/live-view, RDP/RustDesk background restore, cloud sync and first-install behavior.
 
-## Local-only state
+## Local-only boundary
 
-SDKs, signing profiles, AGConnect configuration, local properties, build caches, logs, screenshots, device databases and Codex's private machine memory are intentionally not represented here.
+SDKs, signing profiles, AGConnect configuration, `local.properties`, real `build-profile.json5`, build caches, device data, raw logs, screenshots, private device addresses and Codex's original machine memory are intentionally not represented here.

--- a/docs/codex/CURRENT.md
+++ b/docs/codex/CURRENT.md
@@ -8,6 +8,7 @@ Updated: 2026-07-23 Asia/Shanghai
 - Public branch: `main`
 - Public main commit at audit start: `c502221e3` (`Merge PR #28: refresh shared handoff state`)
 - Audit branch: `codex/windows-memory-sanitize`, based on synchronized `main`
+- Published handoff PR: `#35` (`https://github.com/Mydstiny/RemoteDeskHarmonyOS/pull/35`)
 - No unfinished local `codex/...` branch existed before this audit.
 - The workspace contains user-owned test edits, logs, screenshots, XML and native build evidence. They remain local and are not part of this task.
 

--- a/docs/codex/DECISIONS.md
+++ b/docs/codex/DECISIONS.md
@@ -2,20 +2,60 @@
 
 ## D-001 - GitHub is the public source of truth
 
-GitHub `main` stores public source, tests, scripts, submodule pointers and sanitized coordination state. A machine's private Codex memory is not copied wholesale.
+GitHub `main` stores public source, tests, documents, scripts, submodule pointers and sanitized coordination state. A machine's private Codex memory is not copied wholesale.
 
 ## D-002 - One task, one branch
 
-Each task uses one `codex/<task>` branch. Windows and macOS must not modify the same active branch concurrently. The next device starts from merged `main`.
+Each task uses one `codex/<task>` branch. Windows and macOS must not modify the same active task branch concurrently. The next device starts from merged `main`.
 
 ## D-003 - Sync is a start gate
 
-Starting a task requires a clean `main`, `git fetch --prune origin`, fast-forward-only pull of `origin/main`, recursive submodule update and no other unfinished task branch. Local changes are never auto-stashed or overwritten.
+Starting a task requires a clean `main`, `fetch --prune`, fast-forward-only pull of `origin/main`, recursive submodule update and no other unfinished `codex/...` task branch. Local changes are never auto-stashed or overwritten. When the tree is dirty, stop and preserve the user's files; do not pretend the normal start gate passed.
 
 ## D-004 - Private inputs stay local
 
-Signing files, AGConnect secrets, API keys, SDKs, build caches, user data, raw logs, screenshots and machine-specific paths never enter GitHub or a migration package.
+Signing files, AGConnect secrets, API keys, SDKs, build caches, user data, raw logs, screenshots, device addresses, real `local.properties`, real `build-profile.json5` and private machine paths never enter GitHub or a migration package. Examples may contain placeholders only.
 
 ## D-005 - PR is the handoff boundary
 
-The PR description and `docs/codex/HANDOFF.md` record completed work, verification, blockers and next steps. Merge only after the required open-source compliance check passes.
+The PR description and `docs/codex/HANDOFF.md` record completed work, verification, blockers and next steps. Merge only after the required `open-source-compliance` check passes, using the repository's merge-commit policy rather than squash.
+
+## D-006 - Memory is distilled, not synchronized
+
+Only durable engineering conclusions are rewritten into `docs/codex`. Do not commit raw Codex memory, chat transcripts, session logs or private investigation evidence. Every extracted fact must be either repository-backed, command-verified, or explicitly marked historical/unverified.
+
+## D-007 - HarmonyOS API 23 is the compatibility ceiling
+
+Before changing ArkTS or HarmonyOS APIs, search the local API 23 reference documentation. Do not import `@kit.uiMaterial` or other API 26-only facilities; use API 23-compatible UIDesignKit/HDS or native alternatives. ArkTS strict mode requires declared interfaces/types, forbids `any`/`unknown` in the affected patterns, and uses bracket indexing for dynamic object keys.
+
+## D-008 - Toolchains are machine-local and ABI-explicit
+
+Windows and macOS each configure their own DevEco SDK, native SDK, LLVM/CMake/Ninja, Node/Hvigor/ohpm, Rust/Cargo targets, linker, sysroot and private signing inputs. Do not migrate caches or assume a path from the other OS. OHOS Rust builds must select `aarch64-unknown-linux-ohos` or `x86_64-unknown-linux-ohos` with the matching Clang target and sysroot.
+
+## D-009 - Verification names are part of the contract
+
+Use `default@OhosTestCompileArkTS`; the legacy `default@OhosTestBuildArkTS` is not the valid HarmonyOS extension-Kit gate for this SDK. Native/Rust tests, ABI builds, `assembleHap`, `git diff --check` and the Light compliance gate must be selected according to the changed surface. A Light pass does not claim real-device or Release readiness.
+
+## D-010 - Native dependency provenance is coupled to the change
+
+FreeRDP remains a public gitlink with recursive submodule initialization. RustDesk protocol inputs, FreeRDP, FFmpeg, Opus, OpenSSL, libssh2 or other build inputs require matching provenance, license, SBOM, notice and hash updates. The default configuration keeps `USE_REAL_FREERDP=OFF`; missing optional prebuilt libraries must produce an actionable build message.
+
+## D-011 - Hooks are mandatory publication gates
+
+The repository hook path is `.githooks`. The pre-push hook rejects archive/private history and verifies the actual pushed commit. It resolves `pwsh` first and `powershell.exe` second. Windows PowerShell 5.1 can run the current script set locally, while macOS requires PowerShell 7 for the PowerShell compliance gate. A hook failure is not bypassed by pushing another ref.
+
+## D-012 - Evidence must distinguish code, environment and device state
+
+A build or unit test proves only its own layer. SDK discovery failures, missing credentials, locked devices, WMS/PIP behavior, remote endpoint availability and cloud-account state must be reported as separate environment or device blockers. Do not promote an old log or a historical checkpoint into current acceptance evidence.
+
+## D-013 - Stream correctness is proven after the queue
+
+For RustDesk control/input/file-transfer work, an ArkTS/NAPI enqueue success is insufficient. Logs or counters must prove that the live streaming loop consumed the message. Encrypted TCP frame readers must preserve partial BytesCodec frames across timeout retries; `read_exact()` retries must not discard already-read bytes.
+
+## D-014 - OHOS native APIs need platform-specific substitutes
+
+Do not assume Linux C++ facilities are available in the OHOS NDK. `std::random_device`, `std::filesystem` and some thread/shared-pointer patterns have known limitations. Prefer OHOS Crypto APIs or pthread/POSIX alternatives; `Crypto_DataBlob.len` is bytes, `OH_CryptoRand` Create instances are per-use, and Crypto CMake must link `libohcrypto.so`.
+
+## D-015 - UI lifecycle depends on ownership and mounting
+
+`bindSheet` failures are primarily host-node mounting-timing issues, not a global sheet-count limit. Use a mounted `@Entry` host or a deliberate overlay. For PIP/renderer work, treat `ABOUT_TO_*` as transitional and wait for `STOPPED`/`ERROR`; surface generation, renderer ownership and decoder/frame-pump teardown must be explicit before reattachment.

--- a/docs/codex/HANDOFF.md
+++ b/docs/codex/HANDOFF.md
@@ -2,25 +2,265 @@
 
 Updated: 2026-07-23 Asia/Shanghai
 
-## Source
+## Source and scope
 
-- Base: `main` at `c5347f141`
-- Active task branch: none
-- Last published runtime checkpoint: 1.0.8 stabilization
+- Repository: `Mydstiny/RemoteDeskHarmonyOS`
+- Public base: `main` at `c502221e3`
+- Audit branch: `codex/windows-memory-sanitize`
+- Scope: sanitize Windows Codex development knowledge into public, platform-neutral documentation.
+- Runtime source, tests, dependencies, signing data and user evidence were not changed.
 
-## Completed
+## What was read
 
-- Public source and submodule history are available from GitHub.
-- The shared state files, cross-platform sync entry points and migration package generator are merged on `main`.
+- `AGENTS.md`, `README.md`, `docs/CROSS_DEVICE_GITHUB_WORKFLOW.md`, `docs/BUILD_BASELINE.md`.
+- The four shared `docs/codex` state files and the workflow, build, dependency, compliance and hook scripts.
+- Build/test, FreeRDP provenance, RustDesk FFI reproducible-build, Opus, signing and IDE-related project documents.
+- Selected Windows Codex memory covering API 23, ArkTS strict mode, bindSheet mounting, OHOS Crypto/C++ limitations, RustDesk frame boundaries/control consumption, PIP lifecycle and public Git workflow.
 
-## Verification
+Raw memory directories, chat/session transcripts, device logs, screenshots, crash reports and private paths were not copied or committed.
 
-- Runtime checkpoint gates are recorded in the relevant `docs/test-results/` files and public PR history.
-- Cross-device scripts still need a clean-clone smoke test on both operating systems.
+## Windows environment audit
+
+| Component | Windows result | Mac status |
+| --- | --- | --- |
+| DevEco Studio | `6.1.1.280` installation metadata | Not verified |
+| HarmonyOS/API | Repository targets `6.1.0(23)` / API 23; SDK and native SDK layout present | Install and verify locally |
+| Runtime/project | `runtimeOS: HarmonyOS`, product `default`, module `entry` | Same project settings expected |
+| Bundled Node | `18.20.1` | Not verified |
+| Hvigor | CLI `6.24.2` | Not verified |
+| ohpm | `6.1.2.268` | Not verified |
+| CMake / Ninja | `3.29.2` / `1.12.0` | Not verified |
+| LLVM/Clang | `15.0.4` | Not verified |
+| Rust / Cargo | `1.96.0` / `1.96.0` | Not verified |
+| Rust targets | `aarch64-unknown-linux-ohos`, `x86_64-unknown-linux-ohos` installed | Install and verify both |
+| PowerShell | Windows PowerShell `5.1.26100.8875`; `pwsh` absent | Install PowerShell 7 for hook/compliance |
+| FreeRDP | Repository baseline `3.26.1-dev0`; public gitlink; default `USE_REAL_FREERDP=OFF` | Initialize recursive submodule |
+| Opus | Build script pins `1.5.2` | Build locally when RustDesk input changes |
+| OpenSSL/libssh2 | Historical project baseline only; not revalidated in this audit | Configure local artifacts |
+
+The repository's example product configuration is the safe source for `entry`, `default`, API 23 and `runtimeOS`. Real signing fields, AGConnect values and local properties were intentionally not read.
+
+## IDE continuation procedure
+
+1. Open the repository root in DevEco Studio, not only the `entry` directory.
+2. Let the IDE index the project and import the `entry` module and `default` target. Confirm product `default`, `runtimeOS: HarmonyOS`, device types and API 23 SDK selection.
+3. Configure each machine's SDK, native SDK, Node, Hvigor, ohpm, Rust target, linker and sysroot. Do not copy build caches or signing material from Windows to Mac.
+4. Use the IDE task search or Hvigor wrapper for `default@OhosTestCompileArkTS`; use `ohosTest@OhosTestCompileArkTS` for the test module. Do not use the obsolete `default@OhosTestBuildArkTS` gate.
+5. Build `assembleHap` for product `default`. Expected stages include ArkTS, native compilation/link, package/packing checks and signing when the local profile is configured. A signed HAP is local output, not migration content.
+6. Attach a permitted HarmonyOS device through the local `hdc` configuration and inspect build/deploy logs in DevEco. Device addresses, identifiers and logs remain local.
+
+## Standard commands
+
+Commands below use repository-relative paths and placeholders so they can be run on either machine after local toolchain setup.
+
+### Synchronization and task branch
+
+Windows:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/dev_workflow.ps1 sync
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/dev_workflow.ps1 start -Task <lowercase-kebab-task>
+```
+
+macOS/Linux:
+
+```sh
+./scripts/sync_workspace.sh sync
+./scripts/sync_workspace.sh start <lowercase-kebab-task>
+```
+
+Expected result: clean `main`, `origin/main` fast-forward synchronized, recursive submodule update, no other unfinished task branch, then one new `codex/<task>` branch. A dirty tree must stop the workflow and preserve the local files.
+
+### ArkTS, native, Rust and HAP validation
+
+```text
+default@OhosTestCompileArkTS
+ohosTest@OhosTestCompileArkTS
+cargo fmt --check
+cargo test --lib --no-default-features
+bash scripts/build_opus_ohos.sh all
+bash scripts/build_rustdesk_ffi_ohos.sh all
+bash scripts/build_freerdp_ohos.sh all       # only when real FreeRDP is enabled/needed
+assembleHap --mode module --module entry --product default
+```
+
+The RustDesk build script maps `arm64-v8a` to `aarch64-unknown-linux-ohos` and `x86_64` to `x86_64-unknown-linux-ohos`, sets the matching Clang/sysroot variables, builds Opus first and checks exported FFI symbols. `nm` pipelines must not use `grep -q` under `pipefail`; use a non-early-exit match such as `grep -Eq` or capture output first.
+
+Native tests are generated as `rdp_native_tests` by the project CMake configuration. Run the selected test binary or its DevEco/CTest target on the matching ABI. The public 2026-07-23 checkpoint recorded `129 passed, 0 failed`; real device behavior remains separate.
+
+### Compliance and publication
+
+```powershell
+git diff --check
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/verify_open_source_release.ps1 -Mode Light
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test_workflow_scripts.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test_pre_push_history_guard.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test_opus_artifact_location.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/dev_workflow.ps1 finish-check
+```
+
+`finish-check` requires a non-main branch, a clean tree, `main` as an ancestor and an upstream branch, then reruns the Light gate. The pre-push hook verifies the pushed commit in a temporary detached worktree, refuses archive/private history and runs Light for ordinary branches. Do not bypass it or push `main` directly.
+
+## Sanitized pitfalls
+
+### P-001
+
+- ID: `P-001`
+- 平台: Both
+- 现象: API imports compile or run on a newer SDK but fail on the target device.
+- 根因: Full HarmonyOS SDK/API 23 native SDK assumptions were mixed; `uiMaterial` is API 26-only.
+- 正确修复: Select API 23, read the local API 23 reference first, and use API 23-compatible UIDesignKit/HDS/native APIs.
+- 错误做法: Copy an API 26 sample or import `@kit.uiMaterial` into this API 23 product.
+- 验证命令: `default@OhosTestCompileArkTS`; API 23 device smoke test.
+- 当前状态: 已修复/已知限制; the repository configuration is API 23, but every new API still needs review.
+- 是否适合写入长期规则: 是
+
+### P-002
+
+- ID: `P-002`
+- 平台: Both
+- 现象: Cargo build cannot link, links the wrong architecture or fails while compiling a native dependency.
+- 根因: Cargo target, OHOS Clang target, sysroot or linker was inferred from the host instead of selected explicitly.
+- 正确修复: Configure the matching OHOS Rust target, Clang/C++/AR variables and native sysroot for each ABI; build both ABIs when the release contract requires it.
+- 错误做法: Reuse a Linux/macOS linker or copy a Windows absolute SDK path to Mac.
+- 验证命令: `rustup target list --installed`; `bash scripts/build_rustdesk_ffi_ohos.sh all`; `assembleHap`.
+- 当前状态: 已修复/待 Mac 验证; scripts encode the target mapping, but Mac setup is not verified.
+- 是否适合写入长期规则: 是
+
+### P-003
+
+- ID: `P-003`
+- 平台: Both
+- 现象: Bash dependency scripts cannot find the SDK after variables were set in PowerShell, or PowerShell commands fail on Mac.
+- 根因: Environment assignment syntax and path separators differ between shells; Windows backslashes can also reach Bash unchanged.
+- 正确修复: Set `DEVECO_SDK_HOME`/`OHOS_SDK_HOME` in the shell that invokes the script, normalize paths in Bash and use `powershell.exe`/`pwsh` only for PowerShell scripts.
+- 错误做法: Paste `$env:NAME=...` into Bash or `export NAME=...` into PowerShell.
+- 验证命令: `scripts/check_native_deps.ps1`; `bash scripts/build_opus_ohos.sh all`.
+- 当前状态: 已知限制; scripts contain platform-specific entry points, but three requested resolver scripts are absent.
+- 是否适合写入长期规则: 是
+
+### P-004
+
+- ID: `P-004`
+- 平台: Both
+- 现象: A symbol check reports failure even though the symbol exists.
+- 根因: `set -o pipefail` combined with `nm | grep -q` lets `grep` exit early and makes `nm` report SIGPIPE.
+- 正确修复: Use `grep -Eq` without early exit or capture `nm` output before matching.
+- 错误做法: Treat every pipeline nonzero status as a missing symbol without checking SIGPIPE.
+- 验证命令: `bash scripts/build_rustdesk_ffi_ohos.sh <abi>` and the symbol checks in that script.
+- 当前状态: 已修复; the current script uses non-quiet extended matching.
+- 是否适合写入长期规则: 是
+
+### P-005
+
+- ID: `P-005`
+- 平台: Both
+- 现象: ArkTS test compilation fails with missing HarmonyOS Kit imports or a secondary SourceMap error.
+- 根因: `default@OhosTestBuildArkTS` is the legacy task and does not receive the current HarmonyOS extension API path.
+- 正确修复: Run `default@OhosTestCompileArkTS` and the corresponding `ohosTest` compile task.
+- 错误做法: Use the old task name as the release acceptance gate or fix the secondary SourceMap exception first.
+- 验证命令: `default@OhosTestCompileArkTS`; `ohosTest@OhosTestCompileArkTS`.
+- 当前状态: 已修复; the 2026-07-13 recovery record passed both compile tasks.
+- 是否适合写入长期规则: 是
+
+### P-006
+
+- ID: `P-006`
+- 平台: Windows / macOS
+- 现象: DevEco imports but Hvigor, Node or ohpm is not found; on this Windows shell `pwsh` is missing.
+- 根因: IDE-bundled tools are not guaranteed to be on PATH, and PowerShell 7 is not part of every Windows installation.
+- 正确修复: Configure explicit machine-local tool paths; use Windows PowerShell when the repository script supports it, and install PowerShell 7 on Mac for the hook/compliance gate.
+- 错误做法: Assume the IDE automatically exports all tool paths, or silently skip the hook when `pwsh` is missing.
+- 验证命令: `node --version`; `ohpm --version`; `powershell.exe -File scripts/dev_workflow.ps1 status`; `git config --get core.hooksPath`.
+- 当前状态: 已知限制; Windows versions were measured, Mac discovery is pending.
+- 是否适合写入长期规则: 是
+
+### P-007
+
+- ID: `P-007`
+- 平台: Both
+- 现象: Real FreeRDP builds fail after a clone, or source differs between machines.
+- 根因: `freerdp/` is a gitlink and recursive submodules were not initialized or the source origin/revision was changed.
+- 正确修复: Clone with `--recurse-submodules` or run `git submodule update --init --recursive`; preserve the public gitlink and provenance.
+- 错误做法: Copy a dirty build directory or switch to an untracked mirror without updating provenance.
+- 验证命令: `git submodule status --recursive`; `powershell.exe -File scripts/check_native_deps.ps1`.
+- 当前状态: 已修复/待 Mac 验证; public source is recorded, clean-clone verification remains queued.
+- 是否适合写入长期规则: 是
+
+### P-008
+
+- ID: `P-008`
+- 平台: Both
+- 现象: A local commit pushes without the expected compliance check, or a private/archive ref is exposed.
+- 根因: `core.hooksPath` was not `.githooks`, or the pre-push hook was bypassed.
+- 正确修复: Install the repository hook, confirm `.githooks`, and let the hook verify the exact pushed tip in a temporary worktree.
+- 错误做法: Use `--no-verify`, push `main`, push archive refs, or force-push to work around a failure.
+- 验证命令: `powershell.exe -File scripts/install_git_hooks.ps1`; `git config --get core.hooksPath`; `scripts/tests/test_pre_push_history_guard.ps1`.
+- 当前状态: 已修复/待本分支验证; hook logic and tests are tracked.
+- 是否适合写入长期规则: 是
+
+### P-009
+
+- ID: `P-009`
+- 平台: Both
+- 现象: Two devices overwrite each other's task progress or a new task starts from stale code.
+- 根因: Both devices edited one active branch, or a task started without syncing merged `main`.
+- 正确修复: Use `main -> sync -> codex/<task> -> commit -> push -> PR -> required check -> merge commit -> main -> sync`; allow one active task branch only.
+- 错误做法: Continue from an old branch, push directly to `main`, squash away the handoff boundary, or use `git add -A`.
+- 验证命令: `scripts/sync_workspace.sh status` or `powershell.exe -File scripts/dev_workflow.ps1 status`; `finish-check`.
+- 当前状态: 已修复; shared workflow is public, and this audit updates stale commit state.
+- 是否适合写入长期规则: 是
+
+### P-010
+
+- ID: `P-010`
+- 平台: Both
+- 现象: A clean clone cannot sign or connect to cloud services, or private values leak into a PR.
+- 根因: Signing profile, AGConnect file and `local.properties` are machine-local and were treated as source files.
+- 正确修复: Create them from safe examples or private AGC/DevEco channels on each machine; verify only presence and configuration shape.
+- 错误做法: Commit `.p12`, `.p7b`, `.cer`, secret-bearing AGConnect content, real build profile or local properties.
+- 验证命令: `git ls-files build-profile.json5 local.properties entry/src/main/resources/rawfile/agconnect-services.json`; Light compliance gate.
+- 当前状态: 已修复; private files are present only as local configuration and are not tracked by the public tree.
+- 是否适合写入长期规则: 是
+
+### P-011
+
+- ID: `P-011`
+- 平台: Both
+- 现象: OHOS native code fails to compile, links the wrong crypto library or produces memory/length errors.
+- 根因: Linux C++/OpenSSL assumptions were applied to OHOS NDK and `Crypto_DataBlob.len`/random instance ownership were misunderstood.
+- 正确修复: Use OHOS Crypto APIs, pthread/POSIX alternatives where required, byte lengths, per-use `OH_CryptoRand` instances and `libohcrypto.so`.
+- 错误做法: Assume `std::filesystem`/`std::random_device`/all `std::thread` helpers are available or link `libcrypto_framework.so` for the OHOS Crypto API.
+- 验证命令: Native CMake test target; `assembleHap`; targeted crypto tests where available.
+- 当前状态: 已知限制; durable implementation guidance exists, but each ABI/build still needs validation.
+- 是否适合写入长期规则: 是
+
+### P-012
+
+- ID: `P-012`
+- 平台: Both
+- 现象: RustDesk video/input/file transfer appears queued successfully but later freezes or has frame-size/decrypt errors.
+- 根因: Enqueue success does not prove streaming-loop consumption; timeout retries can lose partial encrypted BytesCodec frames and desynchronize the stream.
+- 正确修复: Instrument and prove consumption in the live loop; retain partial headers/payloads across timeout retries before decrypting complete frames.
+- 错误做法: Keep changing ArkTS controls or GL timing after only observing NAPI enqueue success, or retry `read_exact()` from the middle of a frame.
+- 验证命令: `cargo test --lib --no-default-features`; targeted crypto/control tests; filtered sanitized runtime evidence.
+- 当前状态: 已修复 in the recorded public checkpoints; endpoint and device retest remains separate.
+- 是否适合写入长期规则: 是
+
+## Verification evidence summary
+
+- Public history: current `main` is `c502221e3`; previous handoff docs were stale at `c5347f141` and are corrected here.
+- Repository checks recorded in public test results: native `rdp_native_tests` `129 passed, 0 failed`; `default@OhosTestCompileArkTS` passed; production `assembleHap` passed; Light compliance passed.
+- This audit verified Windows tool versions, API 23 documentation presence, product/module configuration, missing Mac resolver scripts and the clean public base. It did not claim Mac or real-device acceptance.
+- The first direct workflow status run was blocked by a local Git global-ignore permission warning and by missing `pwsh`; no repository files were changed to hide that environment issue.
 
 ## Next owner action
 
-1. Clone or restore the project on the next device.
-2. Configure the local SDK, private files and Git hook.
-3. Run the platform-specific `start` command in `docs/CROSS_DEVICE_GITHUB_WORKFLOW.md`.
-4. Update this handoff with the new branch, verification and blocker state.
+1. Finish the four-file document validation and commit them with DCO sign-off on `codex/windows-memory-sanitize`.
+2. Push only that branch, create a PR targeting `main`, and wait for `open-source-compliance`.
+3. Merge with a merge commit, return to synchronized `main`, and send the PR/commit reference to the Mac operator.
+4. On Mac, configure private inputs locally, run the sync/doctor/clean-clone checks, and update this handoff only with sanitized evidence.
+
+## Explicit exclusion confirmation
+
+This handoff contains no passwords, tokens, API keys, private-key contents, certificate contents, AGConnect secrets, real signing fields, raw Codex memory, session transcripts, logs, screenshots, device data, device serials or build artifacts.

--- a/docs/codex/HANDOFF.md
+++ b/docs/codex/HANDOFF.md
@@ -7,6 +7,8 @@ Updated: 2026-07-23 Asia/Shanghai
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
 - Public base: `main` at `c502221e3`
 - Audit branch: `codex/windows-memory-sanitize`
+- Handoff commit: `27e185f42` (`docs(codex): record Windows development handoff`)
+- Pull request: `https://github.com/Mydstiny/RemoteDeskHarmonyOS/pull/35`
 - Scope: sanitize Windows Codex development knowledge into public, platform-neutral documentation.
 - Runtime source, tests, dependencies, signing data and user evidence were not changed.
 

--- a/docs/codex/QUEUE.md
+++ b/docs/codex/QUEUE.md
@@ -4,20 +4,25 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Now
 
-- Verify the cross-device synchronization gate on a clean Windows clone and a clean macOS clone.
-- Complete real-device acceptance for the published PIP/live-view/cloud-sync/first-install checkpoints.
+- Complete the Windows memory sanitization audit on `codex/windows-memory-sanitize`.
+- Run `git diff --check`, the Light open-source gate, the workflow parser tests and the repository finish check without staging user-owned files.
+- Push the branch, open a PR to `main`, wait for `open-source-compliance`, then merge with a merge commit.
 
 ## Next
 
-- Run the remaining RDP authentication, input, clipboard and RustDesk endpoint matrices.
-- Keep release readiness blocked until credential rotation, device coverage and private signing requirements are evidenced.
+- On macOS, sync the merged `main` with `./scripts/sync_workspace.sh sync` and verify recursive FreeRDP submodules.
+- Configure Mac-local DevEco/API 23 SDK, native toolchain, Rust targets, PowerShell 7, signing profile and AGConnect file through private channels.
+- Run the clean-clone smoke checks and record only sanitized pass/fail summaries.
 
 ## Later
 
-- Extend remote file-transfer coverage and complete the deferred release matrix.
+- Complete real-device acceptance for RustDesk and RDP PIP/live-view registration, repeated foreground/background cycles and no-session exit behavior.
+- Complete cloud-sync protection, first-install white-screen and full four-protocol release matrices on an unlocked target.
+- Keep VNC, deferred file-transfer coverage and remaining release evidence separate from the migration handoff.
 
 ## Queue rules
 
-- Only one task may be active in `Now` on the shared branch state.
-- A new device must sync and read this queue before creating a branch.
-- Finished items are removed or summarized in `CURRENT.md`; do not append an unbounded session transcript.
+- Only one daily `codex/<task>` branch may be active in the shared workspace.
+- A new device must sync merged `main`, read `CURRENT.md`, `QUEUE.md`, `DECISIONS.md` and `HANDOFF.md`, and confirm a clean working tree before creating a task branch.
+- User-owned changes are never auto-stashed, deleted, reset or mixed into a documentation commit.
+- Completed items are removed or summarized in `CURRENT.md`; this file is not a session transcript.


### PR DESCRIPTION
## What changed

- Reconciled the shared handoff state with public `main` at `c502221e3`.
- Distilled Windows-only Codex memory into sanitized, platform-neutral development rules.
- Recorded API 23/ArkTS, DevEco/Hvigor, native/Rust ABI, FreeRDP/RustDesk, Opus, signing, hook and Git workflow requirements.
- Added 12 structured pitfalls with platform, root cause, repair, validation and long-term-rule status.
- Recorded Windows tool observations and explicitly marked Mac and real-device checks as pending.

## Validation

- `git diff --check` passed.
- `verify_open_source_release.ps1 -Mode Light` passed.
- Workflow policy tests passed.
- Opus artifact location test passed.
- Pre-push public-history guard test passed.
- No runtime source or dependency files were changed.

## Privacy boundary

No raw Codex memory, chat/session logs, secrets, signing contents, AGConnect values, local properties, device data, screenshots, logs or build artifacts are included.