### PR TITLE
docs(codex): integrate Windows development handoff

### DIFF
--- a/docs/codex/CURRENT.md
+++ b/docs/codex/CURRENT.md
@@ -6,9 +6,9 @@ Updated: 2026-07-23 Asia/Shanghai
 
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
 - Public branch: `main`
-- Current public `main`: `e9ea4f541` (PR #33, merged with a merge commit)
 - Last workflow change: `dc715d230` (PR #32, merged with a merge commit)
-- Active task: none; the completed Mac `hdc` toolchain fix is already merged.
+- Active task: none; the sanitized Windows development handoff is now included
+  alongside the completed Mac migration state.
 - Shared state is synchronized with public `main`; the next device must sync before
   starting an independent task.
 
@@ -25,6 +25,9 @@ Updated: 2026-07-23 Asia/Shanghai
 - Both the full DevEco SDK and standalone API 23 SDK contain executable arm64
   `hdc` binaries. `scripts/macos_env.sh` now adds the full HarmonyOS SDK
   `toolchains` first and the standalone API 23 `toolchains` as a fallback.
+- Windows-derived durable constraints are recorded in `DECISIONS.md` and
+  `HANDOFF.md`; raw Codex memory, session transcripts and device evidence remain
+  excluded.
 
 ## Completed verification
 
@@ -55,6 +58,10 @@ Updated: 2026-07-23 Asia/Shanghai
 - After `source scripts/macos_env.sh`, `hdc --version` resolves to DevEco hdc
   `3.2.0d`. `hdc start` succeeds; `hdc list targets` reports `[Empty]` because no
   HarmonyOS device or emulator is currently connected and authorized.
+- The Windows handoff snapshot reports DevEco Studio `6.1.1.280`, bundled Node
+  `18.20.1`, Hvigor `6.24.2`, ohpm `6.1.2.268`, OHOS LLVM `15.0.4`, Rust/Cargo
+  `1.96.0`, and both OHOS Rust targets. These are Windows facts, not Mac path
+  assumptions.
 
 ## Blockers
 
@@ -66,6 +73,8 @@ Updated: 2026-07-23 Asia/Shanghai
   channel only if cloud features or cloud-device validation are needed.
 - Device validation remains pending until a HarmonyOS device or emulator is
   connected and authorized for `hdc`.
+- The Windows snapshot has Windows PowerShell `5.1` but no `pwsh`; install
+  PowerShell 7 before using the mandated Windows publication workflow.
 - The repository-local PowerShell 7 fallback (`7.7.0-preview.3`) passes the
   compliance gate; a stable system PowerShell 7 install is still recommended but
   is not blocking this workspace.

--- a/docs/codex/DECISIONS.md
+++ b/docs/codex/DECISIONS.md
@@ -52,3 +52,74 @@ hdc list targets
 If the command resolves and the server starts but the target list is `[Empty]`,
 the toolchain is working and no HarmonyOS device or emulator is connected and
 authorized yet.
+
+## D-009 - API 23 is the compatibility ceiling
+
+The project targets HarmonyOS API 23. Before adding an API or UI import, consult
+the local API 23 reference; API 26-only facilities such as `@kit.uiMaterial` are
+not valid substitutes. ArkTS strict mode requires declared interfaces and types,
+rejects the affected `any`/`unknown` patterns, and uses bracket indexing for
+dynamic object keys.
+
+## D-010 - Toolchains are machine-local and ABI-explicit
+
+Windows and macOS configure their own DevEco SDK, native SDK, LLVM/CMake/Ninja,
+Node/Hvigor/ohpm, Rust targets, linkers, sysroots and private signing inputs.
+Never copy caches or absolute paths across operating systems. OHOS Rust builds
+must select `aarch64-unknown-linux-ohos` or `x86_64-unknown-linux-ohos` with the
+matching Clang target and sysroot.
+
+## D-011 - Verification task names are part of the contract
+
+Use `default@OhosTestCompileArkTS` and the matching
+`ohosTest@OhosTestCompileArkTS` task. The legacy
+`default@OhosTestBuildArkTS` task is not the acceptance gate for this SDK.
+Select native/Rust tests, both ABI builds, `assembleHap`, `git diff --check` and
+the Light compliance gate according to the changed surface; a Light pass does
+not claim real-device or release readiness.
+
+## D-012 - Native dependency provenance follows the change
+
+FreeRDP remains a public gitlink with recursive submodule initialization. Any
+FreeRDP, RustDesk protocol input, FFmpeg, Opus, OpenSSL, libssh2 or other native
+dependency change requires matching provenance, license, SBOM, notice and hash
+updates. Do not replace a public gitlink with a dirty copied build directory.
+
+## D-013 - Hooks are mandatory publication gates
+
+The `.githooks` path and pre-push history/compliance checks are part of the
+publication contract. Do not use `--no-verify`, push `main`, force-push, or work
+around a hook failure by pushing another ref. Windows development still needs
+PowerShell 7 (`pwsh`) for the mandated workflow even when local scripts happen
+to run under Windows PowerShell 5.1.
+
+## D-014 - Evidence must distinguish code, environment and device state
+
+A build or unit test proves only its own layer. SDK discovery, missing private
+credentials, locked devices, WMS/PIP behavior, endpoint availability and cloud
+account state must be recorded as separate environment or device blockers. Do
+not promote an old log or historical checkpoint into current acceptance
+evidence.
+
+## D-015 - Stream correctness is proven after the queue
+
+For RustDesk control, input and file-transfer work, enqueue success does not
+prove that the live streaming loop consumed the message. Encrypted TCP readers
+must preserve partial BytesCodec headers and payloads across timeout retries;
+`read_exact` retries must not discard bytes already read from a frame.
+
+## D-016 - OHOS native APIs need platform-specific substitutes
+
+Do not assume Linux C++ facilities are available in the OHOS NDK. Known fragile
+assumptions include `std::random_device`, `std::filesystem` and some threading
+helpers. Prefer OHOS Crypto or pthread/POSIX alternatives where required;
+`Crypto_DataBlob.len` is measured in bytes, random instances are per-use, and
+OHOS Crypto builds link the matching `libohcrypto.so`.
+
+## D-017 - UI lifecycle depends on ownership and mounting
+
+`bindSheet` failures are commonly host mounting-timing issues rather than a
+global sheet-count limit. Use a mounted entry host or deliberate overlay. For
+PIP and renderer work, treat transitional callbacks as transitional, wait for
+terminal states, and make surface generation, renderer ownership and decoder
+teardown explicit before reattachment.

--- a/docs/codex/HANDOFF.md
+++ b/docs/codex/HANDOFF.md
@@ -4,8 +4,10 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Source
 
-- Current public `main`: `e9ea4f541`, with PR #33 merged using a merge commit
+- Public source of truth: current synchronized `main`
 - Mac hdc workflow fix: `dc715d230`, with PR #32 merged using a merge commit
+- Windows source reviewed: sanitized commit `27e185f42` on
+  `codex/windows-memory-sanitize`; its durable conclusions are integrated below
 - Active task branch: none
 - FreeRDP submodule: `dae8276ac7361b8d14f7b87d41163fe03dbb944e`
 
@@ -30,6 +32,48 @@ Updated: 2026-07-23 Asia/Shanghai
   authorized.
 - `AGENTS.md` now directs both platforms to the sanitized `docs/codex/` state and
   explicitly forbids sharing raw Codex memory directories.
+
+## Windows handoff snapshot
+
+The Windows-side sanitized audit reported the following machine-local tool
+versions. They document the known Windows baseline and must not be turned into
+Mac absolute paths:
+
+- DevEco Studio `6.1.1.280`, bundled Node `18.20.1`, Hvigor `6.24.2` and ohpm
+  `6.1.2.268`.
+- CMake `3.29.2`, Ninja `1.12.0`, OHOS LLVM/Clang `15.0.4`.
+- Rust/Cargo `1.96.0` with `aarch64-unknown-linux-ohos` and
+  `x86_64-unknown-linux-ohos` installed.
+- Windows PowerShell `5.1` was present but `pwsh` was absent in that snapshot;
+  install PowerShell 7 before the mandated Windows sync, finish-check and push
+  workflow.
+- API 23 reference documentation was available locally on Windows. Its contents,
+  paths and raw evidence remain local-only.
+
+## Durable Windows development notes
+
+- Treat API 23 as the compatibility ceiling. Check the local API 23 reference
+  before importing HarmonyOS APIs; do not use API 26-only `@kit.uiMaterial`.
+  Keep ArkTS strict types explicit and use bracket indexing for dynamic keys.
+- Keep each OS's SDK, native SDK, LLVM/CMake/Ninja, Rust target, linker and
+  sysroot machine-local. Build the matching `aarch64-unknown-linux-ohos` and
+  `x86_64-unknown-linux-ohos` ABIs explicitly when the change affects native
+  output.
+- Use `default@OhosTestCompileArkTS` and `ohosTest@OhosTestCompileArkTS`; the
+  legacy `default@OhosTestBuildArkTS` task is not the current API 23 acceptance
+  gate. Separate build evidence from real-device evidence.
+- OHOS native code may need Crypto or pthread/POSIX substitutes for Linux C++
+  facilities. `Crypto_DataBlob.len` is bytes, random instances are per-use, and
+  OHOS Crypto code links `libohcrypto.so`.
+- RustDesk queue/enqueue success does not prove live-loop consumption. Preserve
+  partial encrypted TCP/BytesCodec frames across timeout retries and prove
+  consumption in the streaming loop before changing UI or renderer timing.
+- `bindSheet` depends on a mounted host and ownership. PIP and renderer callbacks
+  are transitional; wait for terminal states and make surface, decoder and
+  renderer teardown explicit before reattachment.
+- Keep the `.githooks` publication gate enabled, use one task branch at a time,
+  and never share raw Codex memory, logs, screenshots, device data, secrets or
+  machine-specific private paths.
 
 ## Verification
 

--- a/docs/codex/QUEUE.md
+++ b/docs/codex/QUEUE.md
@@ -4,12 +4,14 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Now
 
-- No active migration task. The Mac `hdc` PATH fix is verified and merged through
-  PR #32; the next device starts from synchronized `main`.
+- No active migration task. The Mac `hdc` PATH fix and sanitized Windows
+  development handoff are merged through the normal PR flow; the next device
+  starts from synchronized `main`.
 
 ## Next
 
-- On a clean Windows clone, run the same shared-state, submodule and history gates.
+- On Windows, install/confirm PowerShell 7 as `pwsh`, then run the shared-state,
+  submodule and history gates from a clean clone.
 - Configure private signing and optional AGConnect files only on the machine that
   needs signed or cloud-enabled builds.
 - Complete real-device acceptance for RDP, RustDesk, SSH/SFTP, VNC, PIP/live-view


### PR DESCRIPTION
Integrate the sanitized Windows development requirements and durable pitfalls into the shared docs/codex state, using current main as the base.

Included: API 23 compatibility rules, machine-local ABI/toolchain guidance, valid ArkTS verification tasks, native dependency provenance, hook/compliance policy, evidence boundaries, RustDesk stream framing, OHOS native substitutes, UI lifecycle notes, and the Windows toolchain snapshot.

Excluded: raw Codex memory, chat transcripts, logs, screenshots, device data, secrets, signing contents, SDKs and build artifacts.

Verification: git diff --check, DCO commit, finish-check, and Light open-source compliance passed. Merge with a merge commit.