### PR TITLE
docs(codex): close out merged handoff

### DIFF
--- a/docs/codex/CURRENT.md
+++ b/docs/codex/CURRENT.md
@@ -5,9 +5,9 @@ Updated: 2026-07-23 Asia/Shanghai
 ## Repository
 
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
-- Public `origin/main` at merge time: `7e6e65401` (`Merge pull request #36: integrate Windows development handoff`)
+- Public `main` after merge: `a60d0e743` (`Merge pull request #35 from Mydstiny/codex/windows-memory-sanitize`)
 - Previous Windows audit base: `c502221e3`
-- Current audit branch: `codex/windows-memory-sanitize`, now merging the latest public `main`
+- Active task: none; the Windows audit is merged into public `main`
 - Audit commits: `27e185f42`, `a24568990`
 - Audit PR: `#35` (`https://github.com/Mydstiny/RemoteDeskHarmonyOS/pull/35`)
 - No runtime, ArkTS, C/C++, Rust, FreeRDP or dependency source was changed by this audit branch.
@@ -16,7 +16,7 @@ Updated: 2026-07-23 Asia/Shanghai
 ## Current phase
 
 - Windows Codex memory sanitization and cross-device development handoff audit.
-- Public `main` already includes the Mac migration/`hdc` workflow and a prior Windows handoff integration. This branch adds the detailed, structured audit record and merges the latest `main` before PR completion.
+- Public `main` includes the Mac migration/`hdc` workflow, the prior Windows handoff integration and this detailed structured audit record.
 - The normal task start gate was intentionally not used because the workspace contained user-owned changes. The branch was created from synchronized public history without stashing, resetting or deleting those files.
 
 ## Windows evidence collected in this audit
@@ -55,13 +55,13 @@ The old baseline's Node 24 and approximate DevEco 26.0 entries are historical an
 
 - Windows direct checks confirmed the tool versions and API 23 reference availability listed above.
 - `git diff --check`, Light compliance, workflow policy tests, Opus artifact-location tests and the pre-push public-history guard passed before the merge.
-- PR #35 initially became dirty because public `main` advanced concurrently; the latest `origin/main` is being merged normally, without rebase or force-push.
+- PR #35 was merged with a normal merge commit after its `open-source-compliance` check passed.
 - Real-device, cloud-account and Mac clean-clone acceptance remain separate from this document audit.
 
 ## Next
 
-- Resolve and publish the merge update on PR #35, wait for `open-source-compliance`, merge with a merge commit and return the workspace to synchronized `main`.
-- On the next device, read these four files, sync the merged `main`, configure machine-local SDK/toolchains/private inputs and run the platform-specific workflow.
+- On the next device, read these four files, sync `main`, configure machine-local SDK/toolchains/private inputs and run the platform-specific workflow.
+- Keep one task branch active at a time and do not start new work until the next task has been explicitly selected.
 - Complete real-device acceptance for PIP/live-view, RDP/RustDesk background restore, cloud sync and first-install behavior.
 
 ## Local-only boundary

--- a/docs/codex/HANDOFF.md
+++ b/docs/codex/HANDOFF.md
@@ -5,11 +5,12 @@ Updated: 2026-07-23 Asia/Shanghai
 ## Source and scope
 
 - Repository: `Mydstiny/RemoteDeskHarmonyOS`
-- Public base now reviewed: `origin/main` at `7e6e65401`
+- Public `main` after PR merge: `a60d0e743`
 - Previous Windows audit base: `c502221e3`
 - Audit branch: `codex/windows-memory-sanitize`
 - Audit commits: `27e185f42` and `a24568990`
 - Pull request: `https://github.com/Mydstiny/RemoteDeskHarmonyOS/pull/35`
+- Merge result: PR #35 merged with a merge commit after `open-source-compliance` passed (run `30023107202`).
 - Scope: sanitize Windows Codex development knowledge into public, platform-neutral documentation and merge it with the latest Mac handoff state.
 - Runtime source, tests, dependencies, signing data and user evidence were not changed by this audit branch.
 
@@ -262,14 +263,14 @@ On macOS, `scripts/sync_workspace.sh` sources `resolve_powershell.sh` for `finis
 - Windows audit checks: `git diff --check`, `verify_open_source_release.ps1 -Mode Light`, workflow policy tests, Opus artifact-location test and pre-push public-history guard all passed.
 - Public runtime evidence: native `rdp_native_tests` `129 passed, 0 failed`; `default@OhosTestCompileArkTS` passed; production `assembleHap` passed. These do not replace Mac or real-device checks.
 - The first direct workflow status run was blocked by a local Git global-ignore permission warning and by missing `pwsh`; no repository files were changed to hide that environment issue.
-- The current PR became dirty only because `origin/main` advanced concurrently; the resolution uses a normal merge and must be revalidated before merge.
+- The PR became dirty only because `origin/main` advanced concurrently; it was resolved with a normal merge before the required check and final merge.
 
 ## Next owner action
 
-1. Stage only the four resolved `docs/codex` files, commit the merge resolution with DCO sign-off, and push the existing PR branch without force.
-2. Confirm `open-source-compliance` passes for the current PR head, then merge PR #35 with a merge commit.
-3. Return the workspace to synchronized `main`; leave user-owned tests, logs, screenshots and native evidence untouched.
-4. On Mac, source the helper script, run sync/doctor/clean-clone checks, configure private inputs locally and record only sanitized evidence.
+1. On the next device, sync public `main` and read the four shared state files before selecting a new task.
+2. Source the Mac helper script or configure the Windows toolchain locally; do not copy caches, credentials or raw evidence.
+3. Run sync/doctor/clean-clone checks and record only sanitized evidence.
+4. Complete the remaining real-device RDP, RustDesk, SSH/SFTP, VNC, PIP/live-view and cloud-sync acceptance matrix.
 
 ## Explicit exclusion confirmation
 

--- a/docs/codex/QUEUE.md
+++ b/docs/codex/QUEUE.md
@@ -4,12 +4,11 @@ Updated: 2026-07-23 Asia/Shanghai
 
 ## Now
 
-- Finish resolving the public `main` merge on `codex/windows-memory-sanitize`.
-- Re-run document diff, Light compliance, workflow tests and the pre-push guard without staging user-owned files.
-- Update PR #35 against the current `main`, wait for `open-source-compliance`, merge with a merge commit, then return to synchronized `main`.
+- No active migration task. Windows memory sanitization and the Mac migration handoff are merged in `main` through normal merge commits.
 
 ## Next
 
+- On the next task, sync `main` first and confirm a clean working tree.
 - On Windows, confirm PowerShell 7 availability and run the shared-state, submodule and history gates from a clean clone.
 - On macOS, source `scripts/macos_env.sh`, verify the full DevEco SDK/native API 23 SDK role split, Rust targets, `hdc` and the PowerShell resolver.
 - Run the clean-clone smoke checks and record only sanitized pass/fail summaries.


### PR DESCRIPTION
## What changed

- Update `docs/codex/CURRENT.md` to the final public merge commit `a60d0e743`.
- Move `QUEUE.md` from the completed Windows audit to the next-device queue.
- Record PR #35's successful merge and required compliance result in `HANDOFF.md`.

## Validation

- `git diff --check` passed.
- `verify_open_source_release.ps1 -Mode Light` passed.
- Sensitive-path scan passed.
- Only three `docs/codex` files are in this PR.