### PR TITLE
修复 Server Pro 登录与 RustDesk 触控输入的一系列问题

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,6 +1,5 @@
 CompileFlags:
   Add: [-Wunreachable-code-aggressive]
-  Remove: [-fsanitize=hwaddress, -fsanitize=thread]
 Diagnostics:
   ClangTidy:
     Add: [misc-missing-switch-cases,misc-napi-module-name,misc-replace-if-else-with-ternary-operator,misc-unused-local-variable,misc-unused-parameters,modernize-use-auto,readability-system-capabilities,misc-napi-macro-module-name]

--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -1,6 +1,6 @@
 {
   "app": {
-    "bundleName": "com.example.remotedesktop",
+    "bundleName": "com.open.rundesk",
     "vendor": "example",
     "versionCode": 1000008,
     "versionName": "1.0.8",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,43 +1,145 @@
-# CLAUDE.md — 鸿蒙PC双协议远程桌面客户端
+# CLAUDE.md
 
-> **会话启动协议**：每次新会话的第一条消息，必须先执行：
-> 1. 读取 `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\HANDOFF.md` — 上一个 agent 的接力信息
-> 2. 读取 `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\TASKS.md` — 当前任务队列
-> 3. 读取 `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\CODEWALK.md` — 永久项目知识 (首次或变更后)
-> 4. 读取 `C:\Users\14288\.claude\projects\C--Users-14288\memory\MEMORY.md` 索引
-> 5. 读取 `remote-desktop-project-state.md` 记忆
-> 6. 向用户汇报：当前阶段、最新 commit、构建状态、活跃任务、关键规则
-> 7. 从 TASKS.md 领取任务或等待用户指令
->
-> **会话结束协议**：每次结束工作前，必须：
-> 1. 更新 `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\HANDOFF.md` — 元信息、上次会话摘要、下一步
-> 2. 更新 `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\TASKS.md` — 标记完成 + 新增任务
-> 3. 更新 `remote-desktop-project-state.md` 记忆
-> 4. 更新 `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\CODEWALK.md` — 仅当有新架构决策/通用坑位/编码规则时
-> 5. git commit (按 [[always-git-commit]] 规则)
-> 6. 构建验证 (按 [[build-before-git]] 规则)
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## 项目定位
-HarmonyOS NEXT PC 原生远程桌面客户端，四协议（RDP + RustDesk + SSH + VNC）、华为云同步、主机安全锁、沉浸光感UI。
+## 项目
 
-## 当前阶段
-Phase 5+ 完成 → Phase 6 (主机安全锁 40%) + Phase 7 (测试/发布)
+HarmonyOS NEXT PC 原生多协议远程桌面客户端 (RDP + RustDesk + SSH/SFTP + VNC)，
+ArkTS/ArkUI 前端 + C++ NAPI 原生层 + Rust FFI 协议桥，附带华为云同步、本地加密和主机安全锁。
+API 23 是兼容性上限 (`compileSdkVersion 6.1.0(23)`)。
 
-## 权威知识源 (独立交换站)
+## 沟通语言
 
-| 文件 | 位置 |
-|------|------|
-| **CODEWALK.md** | `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\CODEWALK.md` |
-| **HANDOFF.md** | `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\HANDOFF.md` |
-| **TASKS.md** | `C:\Users\14288\DevEcoStudioProjects\Mission_transformation\TASKS.md` |
+**所有面向用户的回复一律使用中文。** 仓库的代码注释、`docs/codex/` 共享状态和本文件都是中文，
+英文回复会脱离项目语境。代码标识符和日志字符串沿用仓库既有风格（英文标识符 + 中文注释）。
 
-> **编代码前先查 `CODEWALK.md`** — 里面有所有编码规则、架构约束和已知坑位。
+## 会话启动
 
-## 本地参考
-- API 23 文档：`C:\Users\14288\harmonyos_support\openharmony-docs-api23\zh-cn\application-dev\reference\`
-- Claude 记忆：`C:\Users\14288\.claude\projects\C--Users-14288\memory\`
-- 构建命令：见 `CODEWALK.md` §8
+在写代码前先读取仓库内的共享状态 (`AGENTS.md` 定义的流程)：
 
----
+1. `docs/codex/CURRENT.md` — 当前阶段、活动分支、blocker
+2. `docs/codex/QUEUE.md` — 任务队列
+3. `docs/codex/DECISIONS.md` — **D-001..D-019 长期有效的架构决策与坑位，改代码前必读**
+4. `docs/codex/HANDOFF.md` — 上一轮交接细节与标准命令（仅在需要时）
 
-> **此文件只包含 Claude 特有的协议和行为规则。共享知识在 Mission_transformation。**
+`AGENTS.md` 中写死的 `C:\Users\14288\...` 路径属于原维护者机器，本 checkout
+(`D:\Codespace\matepad_vpn\RemoteDeskHarmonyOS`) 不适用；仓库内 `docs/codex/` 才是权威共享状态。
+
+## 构建
+
+本机 SDK 通过目录联结 `C:\ohos_sdk` → `C:\Program Files\Huawei\DevEco Studio\sdk`（规避路径空格）。
+
+```powershell
+# 完整 HAP 构建（等价于双击 build_hap.bat）
+$env:DEVECO_SDK_HOME = 'C:\ohos_sdk'
+$env:OHOS_SDK_HOME = 'C:\ohos_sdk'
+& 'C:\Program Files\Huawei\DevEco Studio\tools\node\node.exe' `
+  'C:\Program Files\Huawei\DevEco Studio\tools\hvigor\bin\hvigorw.js' `
+  --mode module -p module=entry -p product=default assembleHap `
+  --analyze=normal --parallel --incremental --daemon
+```
+
+产物：`entry/build/default/outputs/default/entry-default-{unsigned,signed}.hap`
+
+原生依赖（clean clone 或 RustDesk/Opus 输入变化后才需要重建，产物已在 `libs/` 就位）：
+
+```bash
+bash scripts/build_opus_ohos.sh all            # arm64-v8a + x86_64
+bash scripts/build_rustdesk_ffi_ohos.sh all
+bash scripts/build_freerdp_ohos.sh all         # 仅 USE_REAL_FREERDP 需要
+bash scripts/build_ffmpeg_softdec_ohos.sh <arch>
+```
+
+x86_64 单独构建见 `build_x64_deps.bat`（内含 Clang/sysroot/`OPUS_LIB_DIR` 环境变量样板）。
+`libs/` 缺库时 CMake 会给出可执行的错误提示——照提示跑对应脚本，不要改 CMake 绕过。
+
+## 测试
+
+| 层 | 命令 / 入口 |
+|---|---|
+| ArkTS 编译门 | `default@OhosTestCompileArkTS`（测试模块用 `ohosTest@OhosTestCompileArkTS`）— **不要用已废弃的 `default@OhosTestBuildArkTS`** |
+| ArkTS 本地单测 | `entry/src/test/*.test.ets`（hypium），全部在 `entry/src/test/List.test.ets` 手动注册 |
+| ArkTS 设备测试 | `entry/src/ohosTest/ets/test/`，`onDeviceTest` 任务 |
+| Native C++ | `cmake -S entry/src/main/cpp -B <build> -DRDP_BUILD_TESTS=ON -DRDP_TESTS_ONLY=ON` → `cmake --build <build> --target rdp_native_tests` → 运行 `rdp_native_tests[.exe]` |
+| Rust | `cargo test --manifest-path rustdesk_ffi/Cargo.toml --lib --no-default-features` |
+| 合规门 | `pwsh -File scripts/verify_open_source_release.ps1 -Mode Light`（PR required check；tag 走 `-Mode Release`） |
+
+**新增测试必须两处注册**：`.test.ets` 要 import + 调用进 `List.test.ets`；native 测试要加进
+`entry/src/main/cpp/CMakeLists.txt` 的 `rdp_native_tests` 源文件列表。
+跑单个 ArkTS 测试没有 CLI filter——临时在 `List.test.ets` 里只保留目标调用。
+`RDP_TESTS_ONLY=ON` 让 CMake 在配置完测试后 `return()`，跳过全部 OHOS/FreeRDP/Rust 链接，
+是唯一能在宿主机上跑 native 测试的方式。
+
+按变更范围选择验证强度（`AGENTS.md` 的风险分级表）：文档 → `git diff --check` + Light；
+ArkTS/UI → 定向测试 + `OhosTestCompileArkTS` + `assembleHap` + Light；
+C/C++/Rust/FFI → 定向 native/Rust 测试 + 受影响 ABI + `assembleHap` + Light。
+
+## 架构
+
+### 分层
+
+```
+entry/src/main/ets/pages/          ArkUI @Entry 页面（RemoteDesktop.ets 9k+ 行，是会话总控）
+entry/src/main/ets/components/     可复用 UI（含 dialogs/ hostadd/ resourceadd/ 子目录）
+entry/src/main/ets/services/       112 个文件：Service（有状态/有 IO）+ Policy（纯函数）
+entry/src/main/ets/services/ExtensionLoader.ets   ← 唯一的 NAPI 门面（单例）
+entry/src/main/ets/types/rdpnapi.d.ts             ← librdpnapi.so 的 TS 声明（ABI 契约）
+        │
+entry/src/main/cpp/                napi_init.cpp 注册各子系统 *Napi::Init(env, exports)
+        ├── extensions/  会话生命周期、teardown 执行器
+        ├── rdp/         FreeRDP 适配 + 帧调度/损伤累积/GL 上传门/认证策略
+        ├── rustdesk/    rustdesk_bridge.cpp → Rust FFI
+        ├── ssh/ vnc/ terminal/ render/ audio/ input/ security/
+        │
+rustdesk_ffi/src/                  Rust: 协议会话、加密通道、wire 编解码、terminal_core
+freerdp/                           git 子模块（分支 freerdp-ohos）
+```
+
+ArkTS 只通过 `import rdpnapi from 'librdpnapi.so'` 触达原生层，且实际只有三处
+（`ExtensionLoader.ets`、`RemoteDesktop.ets`、`napi/TerminalCoreBridge.ets`）。
+新增原生能力时改动是成套的：C++ 实现 → `napi_init.cpp` 子系统 Init → `rdpnapi.d.ts` 声明 →
+`ExtensionLoader` 方法（try/catch + `ExtensionResult` 包装，绝不让原生异常穿透到 UI）。
+
+### Policy 模式（本仓库最重要的约定）
+
+`services/*Policy.ets` 是**无依赖的纯函数模块**——不 import UI、不碰 NAPI、不做 IO，
+把判定逻辑从 9000 行的页面里抽出来，从而能在 `entry/src/test/` 里离线单测。
+`Service` 才持有状态、RDB、网络和 NAPI 句柄。
+写新交互逻辑时默认先落成 Policy + 单测，页面只负责调用与渲染。
+同一模式在 native 侧重复：`rdp_*_policy.cpp` / `audio_queue_policy.cpp` 等纯 C++ 策略进
+`rdp_native_tests`，带 OHOS 依赖的部分留在适配器里。
+
+### 会话边界
+
+协议会话、渲染、音频、输入、剪贴板、文件传输各自独立。可选能力（音频、剪贴板、共享目录）
+失败不得破坏已建立的桌面会话。云同步与加密写入必须先确认本地事务成功再更新缓存或推送。
+
+## 关键约束
+
+- **API 23 上限**（D-007）：改 HarmonyOS API 前查本地 API 23 文档；禁止 `@kit.uiMaterial` 等 API 26 专有能力。
+  ArkTS 严格模式要求显式接口/类型，避免 `any`/`unknown`，动态键用方括号索引。
+- **`freerdp/` 子模块常年显示 dirty** —— 这是交叉编译产物导致的，**不要 reset**，重置要重新编译数分钟。
+- **`USE_REAL_FREERDP`**：CMake 默认 OFF，但 `entry/build-profile.json5` 用
+  `-DUSE_REAL_FREERDP=ON` 覆盖，所以正常 HAP 构建走真实 FreeRDP，需要 `libs/freerdp-ohos/<abi>/` 预编译产物。
+  `RUSTDESK_USE_REAL_CORE` 在 CMakeLists 中硬编码开启。
+- **双 ABI**：`arm64-v8a` + `x86_64`。Rust 目标分别是 `aarch64-unknown-linux-ohos` /
+  `x86_64-unknown-linux-ohos`，必须配套 Clang target 与 sysroot（D-008）。
+- **OHOS NDK 不是完整 Linux**（D-016）：`std::random_device`、`std::filesystem` 有已知限制；
+  用 OHOS Crypto API（`Crypto_DataBlob.len` 单位是字节，`OH_CryptoRand` 实例一次性）并链接 `libohcrypto.so`。
+- **RustDesk 流正确性**（D-015）：ArkTS/NAPI 入队成功不算数，必须有日志/计数证明流循环真正消费了消息；
+  加密 TCP 读取要跨超时重试保留半帧，`read_exact()` 重试不得丢弃已读字节。
+- **UI 生命周期**（D-017）：`bindSheet` 失败通常是宿主节点挂载时机问题而非数量上限；
+  PIP/渲染器把 `ABOUT_TO_*` 当过渡态，等 `STOPPED`/`ERROR`，重挂载前显式交还 surface/renderer/decoder 所有权。
+- **私有输入不进 Git**：`build-profile.json5`、`local.properties`、`agconnect-services.json`
+  已被 `.gitignore` 排除（各有 `.example` 模板）；签名材料、口令、token、真实主机地址同理。
+
+## Git 与提交
+
+- 一个任务一个分支：`main` → `pull --ff-only` → 功能分支 → PR → required `open-source-compliance` → merge。
+  同一时间只保留一个活动任务分支（D-002）。
+- 禁止 `git add -A`、`git push --all`、直接 push `main`、force-push、`--no-verify`。只暂存本任务明确文件。
+- 所有提交用 `git commit -s`（DCO，见 `CONTRIBUTING.md`）。
+- hook 路径是 `.githooks`（`pwsh -File scripts/install_git_hooks.ps1` 安装）；pre-push 会拦截私有历史。
+- 依赖 / proto / license / gitlink 变化必须在同一 PR 内更新 `docs/compliance/SBOM.spdx.json`、
+  `NOTICE`、provenance 和哈希，否则合规门会拒绝（D-012）。
+- 本仓库主协议为 AGPL-3.0-or-later。

--- a/entry/src/main/cpp/extensions/extension_loader_napi.cpp
+++ b/entry/src/main/cpp/extensions/extension_loader_napi.cpp
@@ -1115,6 +1115,7 @@ napi_value NapiConnect(napi_env env, napi_callback_info info) {
     getString("rdAccountId", cfg.rdAccountId);
     getString("rdServerKey", cfg.rdServerKey);
     getInt("rdServerKeyMode", cfg.rdServerKeyMode);
+    getString("rdProAccessToken", cfg.rdProAccessToken);
 
     if (cfg.rdDirectPort <= 0) cfg.rdDirectPort = 21118;
     if (cfg.port == 0) {
@@ -1153,12 +1154,14 @@ napi_value NapiConnect(napi_env env, napi_callback_info info) {
         const std::string accountLog = cfg.rdAccountId.empty() ? "未设置" : SafeLog::MaskUser(cfg.rdAccountId);
         const char* serverKeyMode = cfg.rdServerKeyMode == 2 ? "shared" :
             (cfg.rdServerKeyMode == 1 ? "public" : "auto");
-        OH_LOG_INFO(LOG_APP, "[ExtLoader] RustDesk配置: quality=%{public}d direct=%{public}s:%{public}d lan=%{public}s privacy=%{public}s audio=%{public}s pwdMode=%{public}d authMode=%{public}d pwdLen=%{public}d relayId=%{public}s account=%{public}s serverKeyMode=%{public}s",
+        // proToken 只报告存在性 — 账号会话 token 绝不进入日志。
+        OH_LOG_INFO(LOG_APP, "[ExtLoader] RustDesk配置: quality=%{public}d direct=%{public}s:%{public}d lan=%{public}s privacy=%{public}s audio=%{public}s pwdMode=%{public}d authMode=%{public}d pwdLen=%{public}d relayId=%{public}s account=%{public}s serverKeyMode=%{public}s proToken=%{public}s",
                     cfg.rdImageQuality, cfg.rdDirectIp ? "on" : "off", cfg.rdDirectPort,
                     cfg.rdLanDiscovery ? "on" : "off", cfg.rdPrivacyMode ? "on" : "off",
                     cfg.rdAudioEnabled ? "on" : "off",
                     cfg.rdPasswordMode, cfg.rdAuthMode, cfg.rdPasswordLength,
-                    relayLog.c_str(), accountLog.c_str(), serverKeyMode);
+                    relayLog.c_str(), accountLog.c_str(), serverKeyMode,
+                    cfg.rdProAccessToken.empty() ? "absent" : "present");
     } else if (protocolName == "rdp") {
         const std::string drivePathLog = cfg.rdDrivePath.empty() ? "off" : SafeLog::HashForLog(cfg.rdDrivePath);
         const char* authMode = cfg.rdpAuthMode == RdpAuthenticationMode::RestrictedAdmin ? "restricted_admin" :

--- a/entry/src/main/cpp/extensions/protocol_adapter.h
+++ b/entry/src/main/cpp/extensions/protocol_adapter.h
@@ -109,6 +109,8 @@ struct ConnectionConfig {
     std::string rdAccountId;       // RustDesk: 绑定 API 账户 ID
     std::string rdServerKey;       // RustDesk: Rendezvous 公钥或共享准入 Key
     int         rdServerKeyMode;   // 0=legacy/auto, 1=server public key, 2=shared access key
+    // RustDesk: Server Pro 账号会话 token。仅本次连接使用，禁止持久化或写入日志。
+    std::string rdProAccessToken;
 
     ConnectionConfig()
         : port(3389), width(1920), height(1080), codec(CodecType::H264),

--- a/entry/src/main/cpp/rustdesk/rustdesk_bridge.cpp
+++ b/entry/src/main/cpp/rustdesk/rustdesk_bridge.cpp
@@ -1127,8 +1127,11 @@ int RustDeskBridge::connect(const ConnectionConfig& cfg) {
         const std::string logPeer = SafeLog::MaskUser(ffiPeerId);
         const char* serverKeyMode = cfg.rdServerKeyMode == 2 ? "shared" :
             (cfg.rdServerKeyMode == 1 ? "public" : "auto");
-        OH_LOG_INFO(LOG_APP, "[RustDesk-FFI] Request peer=%{public}s serverKeyMode=%{public}s",
-                    logPeer.c_str(), serverKeyMode);
+        // 只记录 token 是否存在，绝不记录其内容。
+        OH_LOG_INFO(LOG_APP,
+                    "[RustDesk-FFI] Request peer=%{public}s serverKeyMode=%{public}s proToken=%{public}s",
+                    logPeer.c_str(), serverKeyMode,
+                    cfg.rdProAccessToken.empty() ? "absent" : "present");
 
         RustDeskBridge::Impl* impl = impl_.get();
         std::thread connectThread([impl, cfg, ffiPeerId, logHost, serial]() {
@@ -1150,6 +1153,9 @@ int RustDeskBridge::connect(const ConnectionConfig& cfg) {
             ffiCfg.fps      = 0; // From profile
             ffiCfg.auth_mode = (cfg.rdAuthMode == 1) ? 1 : 0;
             ffiCfg.key_mode = cfg.rdServerKeyMode;
+            // Server Pro 拒绝未登录的 punch hole；会话 token 必须随握手发送。
+            // cfg 按值捕获，c_str() 在 rustdesk_connect 返回前保持有效。
+            ffiCfg.token    = cfg.rdProAccessToken.c_str();
             // T-209: 直连模式映射
             ffiCfg.direct_connection = false;
             if (cfg.rdDirectIp && !cfg.host.empty()) {

--- a/entry/src/main/cpp/rustdesk/rustdesk_bridge.h
+++ b/entry/src/main/cpp/rustdesk/rustdesk_bridge.h
@@ -82,6 +82,9 @@ struct RustDeskFfiConfig {
     bool        direct_connection; // 直连模式: false=rendezvous (默认), true=TCP直连peer
     int         auth_mode;  // 0=设备密码, 1=请求被控端点击批准
     int         key_mode;   // 0=legacy/auto, 1=server public key, 2=shared access key
+    // Server Pro 账号会话 token → PunchHoleRequest.token / RequestRelay.token。
+    // nullptr/空 = OSS 部署，不做账号鉴权。追加在末尾以保持既有 C ABI 字段顺序。
+    const char* token;
 };
 
 enum class RustDeskMode {

--- a/entry/src/main/cpp/types/librdpnapi/index.d.ts
+++ b/entry/src/main/cpp/types/librdpnapi/index.d.ts
@@ -359,6 +359,10 @@ export interface SessionConfig {
   rdAccountId?: string;      // API账户ID
   rdServerKey?: string;      // Rendezvous 公钥或共享准入 Key
   rdServerKeyMode?: number;  // 0=legacy/auto, 1=server public key, 2=shared access key
+  // RustDesk Server Pro 账号会话 token → PunchHoleRequest.token / RequestRelay.token。
+  // 开启账号访问控制的 hbbs 用它鉴权；空 = OSS 部署。
+  // Transient only. Never persist this value in RemoteHost or a cloud payload.
+  rdProAccessToken?: string;
 }
 
 export interface SftpFileEntry {

--- a/entry/src/main/ets/components/RemoteModifierHandle.ets
+++ b/entry/src/main/ets/components/RemoteModifierHandle.ets
@@ -11,9 +11,22 @@ import { hilog } from '@kit.PerformanceAnalysisKit';
 
 const TAG = 'ModifierHandle';
 const DOMAIN = 0x0014;
-const HANDLE_WIDTH = 58;
-const VISIBLE_TAB_WIDTH = 24;
+/**
+ * 修饰键胶囊与键盘按钮的尺寸。
+ *
+ * 键盘是高频操作、修饰键是低频，所以键盘按钮做得比胶囊大。两者宽度都不超过
+ * VISIBLE_TAB_WIDTH，保证贴边时完整露在屏幕内（胶囊本体有一大截是故意藏在
+ * 屏幕外的）。KEY_BUTTON_BLOCK 必须小于父组件 snapHandleToEdge 的 topMargin，
+ * 否则贴到顶部时键盘按钮会被切掉。
+ */
+const HANDLE_WIDTH = 48;
+const VISIBLE_TAB_WIDTH = 34;
 const HIDDEN_LABEL_WIDTH = HANDLE_WIDTH - VISIBLE_TAB_WIDTH;
+const CAPSULE_HEIGHT = 30;
+const KEY_BUTTON_WIDTH = VISIBLE_TAB_WIDTH;
+const KEY_BUTTON_HEIGHT = 44;
+const KEY_BUTTON_GAP = 6;
+const KEY_BUTTON_BLOCK = KEY_BUTTON_HEIGHT + KEY_BUTTON_GAP;
 
 @Component
 export struct RemoteModifierHandle {
@@ -31,8 +44,12 @@ export struct RemoteModifierHandle {
   @Prop shiftLocked: boolean = false;
   @Prop winLocked: boolean = false;
   @Prop fnLayer: boolean = false;
+  /** 软键盘是否已打开 (决定快捷按钮的激活态) */
+  @Prop keyboardOpen: boolean = false;
   @StorageProp('accentColor') accentColor: string = '#007DFF';
 
+  /** 单击键盘快捷按钮 → 直接开关软键盘, 不用先展开面板 */
+  onToggleKeyboard: () => void = (): void => {};
   /** 单击胶囊 → 展开/收起面板 */
   onTogglePanel: () => void = (): void => {};
   /** 长按胶囊 → 打开快捷键面板 */
@@ -130,8 +147,38 @@ export struct RemoteModifierHandle {
   // 构建
   // ============================================================
 
+  /** 露出的工具柄在胶囊本地坐标里的 x，键盘按钮跟它同列才不会被挤到屏幕外。 */
+  private visibleTabLocalX(): number {
+    return this.handleSide === 'left' ? HIDDEN_LABEL_WIDTH : 0;
+  }
+
   build() {
     Stack() {
+      // 键盘快捷按钮 — 一下直达软键盘。用和修饰键面板里同一个系统图标，
+      // 和胶囊工具柄上的 '⌨' 文字字形区分开。
+      Row() {
+        SymbolGlyph($r('sys.symbol.keyboard'))
+          .fontSize(20)
+          .fontColor([this.keyboardOpen ? '#DFFFE6' : '#E6E6E6'])
+      }
+      .justifyContent(FlexAlign.Center)
+      .width(KEY_BUTTON_WIDTH)
+      .height(KEY_BUTTON_HEIGHT)
+      .borderRadius(12)
+      .backgroundColor(this.keyboardOpen ? 'rgba(30,60,44,0.88)' : 'rgba(14,18,28,0.72)')
+      .border({
+        width: this.keyboardOpen ? 1.5 : 1,
+        color: this.keyboardOpen ? 'rgba(102,221,122,0.55)' : 'rgba(255,255,255,0.14)'
+      })
+      .shadow({ radius: 8, color: 'rgba(0,0,0,0.30)', offsetY: 2 })
+      .alignItems(VerticalAlign.Center)
+      .position({ x: this.visibleTabLocalX(), y: 0 })
+      .gesture(TapGesture({ count: 1 })
+        .onAction((): void => {
+          hilog.info(DOMAIN, TAG, 'handle keyboard button → toggle keyboard');
+          this.onToggleKeyboard();
+        }))
+
       // 胶囊本体 — 半透明深色工具柄
       Row() {
         if (this.handleSide === 'left') {
@@ -166,7 +213,7 @@ export struct RemoteModifierHandle {
             .textOverflow({ overflow: TextOverflow.Ellipsis })
         }
       }
-      .height(42)
+      .height(CAPSULE_HEIGHT)
       .width(HANDLE_WIDTH)
       .borderRadius(14)
       .backgroundColor(this.capsuleBg())
@@ -177,6 +224,7 @@ export struct RemoteModifierHandle {
         offsetY: 2
       })
       .alignItems(VerticalAlign.Center)
+      .position({ x: 0, y: KEY_BUTTON_BLOCK })
       .gesture(
         GestureGroup(GestureMode.Exclusive,
           TapGesture({ count: 1 })
@@ -212,8 +260,12 @@ export struct RemoteModifierHandle {
         )
       )
     }
-    .position({ x: this.effectiveX(), y: this.effectiveY() })
+    .width(HANDLE_WIDTH)
+    .height(KEY_BUTTON_BLOCK + CAPSULE_HEIGHT)
+    // 整块上移 KEY_BUTTON_BLOCK，让胶囊本体仍然精确落在父组件给的 handleY 上，
+    // 父组件的吸边与夹取算法不用感知键盘按钮的存在。
+    .position({ x: this.effectiveX(), y: this.effectiveY() - KEY_BUTTON_BLOCK })
     .hitTestBehavior(HitTestMode.Default)
-    // 不铺全屏 — 仅胶囊自身区域响应触摸
+    // 不铺全屏 — 仅胶囊与键盘按钮自身区域响应触摸
   }
 }

--- a/entry/src/main/ets/components/RemoteModifierPanel.ets
+++ b/entry/src/main/ets/components/RemoteModifierPanel.ets
@@ -524,6 +524,10 @@ export struct RemoteModifierPanel {
   private static readonly KEY_SYSRQ = 2079;
   private static readonly KEY_BREAK = 2080;
   private static readonly KEY_INSERT = 2083;
+  private static readonly KEY_DPAD_UP = 2012;
+  private static readonly KEY_DPAD_DOWN = 2013;
+  private static readonly KEY_DPAD_LEFT = 2014;
+  private static readonly KEY_DPAD_RIGHT = 2015;
 
   // ============================================================
   // 构建 — 主面板 (紧凑)
@@ -570,6 +574,20 @@ export struct RemoteModifierPanel {
           this.ActionKey('Tab', RemoteModifierPanel.KEY_TAB)
           this.ActionKey('Del', RemoteModifierPanel.KEY_DEL)
           this.EnterKey()
+        }
+        .width('100%')
+        .justifyContent(FlexAlign.SpaceEvenly)
+
+        Row().height(6)
+
+        // 方向键行: ← ↑ ↓ →
+        // 走和其他动作键同一条 onKeyTap 通路，所以修饰键锁定时会自动组合，
+        // Shift+方向 选择文本、Ctrl+方向 按词跳转都能用。
+        Row() {
+          this.ActionKey('←', RemoteModifierPanel.KEY_DPAD_LEFT)
+          this.ActionKey('↑', RemoteModifierPanel.KEY_DPAD_UP)
+          this.ActionKey('↓', RemoteModifierPanel.KEY_DPAD_DOWN)
+          this.ActionKey('→', RemoteModifierPanel.KEY_DPAD_RIGHT)
         }
         .width('100%')
         .justifyContent(FlexAlign.SpaceEvenly)

--- a/entry/src/main/ets/components/RemoteModifierPanel.ets
+++ b/entry/src/main/ets/components/RemoteModifierPanel.ets
@@ -22,6 +22,7 @@ export struct RemoteModifierPanel {
   @Prop shiftLatch: string = 'off';
   @Prop winLatch: string = 'off';
   @Prop fnLayer: boolean = false;
+  @Prop keyboardOpen: boolean = false;
   @Prop panelX: number = 8;
   @Prop panelY: number = 70;
   @Prop shortcutX: number = 8;
@@ -34,6 +35,14 @@ export struct RemoteModifierPanel {
   onToggleModifier: (mod: string) => void = (_mod: string): void => {};
   onLockModifier: (mod: string) => void = (_mod: string): void => {};
   onToggleFnLayer: () => void = (): void => {};
+  /**
+   * 打开/收起系统虚拟键盘。
+   *
+   * 悬浮胶囊是连接成功后唯一常驻可见的入口；RustDesk 顶栏只在桌面设备或
+   * 键鼠模式下显示，控制面板又只能三指轻点唤出，平板触控模式下用户找不到
+   * 任何打字入口。
+   */
+  onToggleKeyboard: () => void = (): void => {};
   /** 功能键点击回调 (Esc/Tab/Del/Enter/F1-F12 等) */
   onKeyTap: (keyCode: number, label: string) => void = (_kc: number, _lb: string): void => {};
   /** 快捷键点击回调 — keyCodes: [modifier, ..., key] → 全部 down → 逆序 up */
@@ -270,6 +279,38 @@ export struct RemoteModifierPanel {
     )
   }
 
+  /** 虚拟键盘开关 — 面板标题栏常驻入口 */
+  @Builder
+  KeyboardToggle() {
+    Row() {
+      SymbolGlyph($r('sys.symbol.keyboard'))
+        .fontSize(15)
+        .fontColor([this.keyboardOpen ? '#DFFFE6' : 'rgba(242,244,247,0.82)'])
+      Text(this.keyboardOpen ? '收起' : '键盘')
+        .fontSize(11)
+        .fontColor(this.keyboardOpen ? '#DFFFE6' : 'rgba(242,244,247,0.82)')
+        .margin({ left: 4 })
+    }
+    .height(26)
+    .padding({ left: 8, right: 8 })
+    .borderRadius(9)
+    .backgroundColor(this.keyBgFor('kbd-toggle', this.keyboardOpen ? this.fnActiveBg() : this.keyBg()))
+    .border({
+      width: this.keyboardOpen ? 1 : 0.5,
+      color: this.keyBorderFor('kbd-toggle', this.keyboardOpen ? this.fnActiveBorder() : this.keyBorder())
+    })
+    .scale({ x: this.isPressed('kbd-toggle') ? 0.96 : 1, y: this.isPressed('kbd-toggle') ? 0.96 : 1 })
+    .animation({ duration: 80, curve: Curve.EaseOut })
+    .onTouch((event: TouchEvent): void => {
+      this.updatePressedKey('kbd-toggle', event);
+    })
+    .gesture(TapGesture({ count: 1 })
+      .onAction((): void => {
+        hilog.info(DOMAIN, TAG, 'keyboard toggle open=' + (this.keyboardOpen ? '1' : '0'));
+        this.onToggleKeyboard();
+      }))
+  }
+
   /** Fn 层切换按钮 */
   @Builder
   FnKey() {
@@ -496,6 +537,7 @@ export struct RemoteModifierPanel {
         // 标题栏
         Row() {
           this.PanelDragArea('修饰键', false)
+          this.KeyboardToggle()
           Text('✕')
             .fontSize(13)
             .fontColor('rgba(255,255,255,0.4)')

--- a/entry/src/main/ets/model/RustDeskProModels.ets
+++ b/entry/src/main/ets/model/RustDeskProModels.ets
@@ -1,5 +1,3 @@
-import { buffer, util } from '@kit.ArkTS';
-
 /**
  * RustDesk Server Pro 账号与地址簿模型。
  *
@@ -27,10 +25,16 @@ export class RustDeskProPeer {
   note: string = '';
 
   /**
-   * RustDesk personal address books return the remembered password as a
-   * base64-encoded `hash` field. Shared address books may return `password`.
-   * Keep the decoded value in memory only; RemoteHost/CloudStore encrypt it
-   * when it is persisted locally.
+   * 只接受服务器明确返回的明文 `password` 字段。
+   *
+   * 地址簿里的 `hash` **不是密码**，是 `SHA256(password + salt)` 的 32 字节
+   * 二进制摘要（base64 编码）。以前这里把它解码后按 UTF-8 转成字符串当密码用，
+   * 结果有两个问题：
+   *   1. 随机二进制按 UTF-8 解码得到的是乱码，而且是有损转换；
+   *   2. 就算原样保留字节也没用 —— FFI 的认证只接受明文口令，
+   *      protocol/session.rs 会无条件做 SHA256(password+salt) 再
+   *      SHA256(..+challenge) 两轮，喂哈希进去必然认证失败。
+   * 所以 hash 一律忽略，让主机回落到点击批准或用户自己保存的密码。
    */
   password: string = '';
 
@@ -44,14 +48,6 @@ export class RustDeskProPeer {
     peer.note = typeof json['note'] === 'string' ? json['note'] as string : '';
     if (typeof json['password'] === 'string') {
       peer.password = json['password'] as string;
-    }
-    if (peer.password.length === 0 && typeof json['hash'] === 'string') {
-      try {
-        const bytes: Uint8Array = new util.Base64Helper().decodeSync(json['hash'] as string);
-        peer.password = buffer.from(bytes).toString('utf-8');
-      } catch (_err) {
-        // A malformed/unsupported hash must not make the whole address book fail.
-      }
     }
     const rawTags: Object | undefined = json['tags'];
     if (Array.isArray(rawTags)) {

--- a/entry/src/main/ets/pages/HostListPage.ets
+++ b/entry/src/main/ets/pages/HostListPage.ets
@@ -3322,8 +3322,10 @@ struct HostListPage {
       prefs.putSync('loginMode', '');
       prefs.flushSync();
     } catch (_e) { /* ignore */ }
-    // 3. 清空磁盘凭据
-    AccountKitService.getInstance().clearCredential();
+    // 3. 清空磁盘凭据 (未初始化时 clearCredential 只会清内存, 磁盘残留会让下次冷启动"自动登录"回来)
+    const accountKit: AccountKitService = AccountKitService.getInstance();
+    accountKit.initSync(getContext(this) as common.Context);
+    accountKit.clearCredential();
     // 4. 清除 HMS Core 系统级授权 session
     try {
       const cancelReq: authentication.CancelAuthorizationRequest =
@@ -3364,12 +3366,15 @@ struct HostListPage {
         credential.openID ?? ''
       );
       // 持久化 (参照 LoginPage.onLoginSuccess)
-      AccountKitService.getInstance().saveCredential({
+      const accountKit: AccountKitService = AccountKitService.getInstance();
+      accountKit.initSync(getContext(this) as common.Context);
+      accountKit.saveCredential({
         unionID: credential.unionID ?? '',
         openID: credential.openID ?? '',
         authorizationCode: credential.authorizationCode ?? '',
         idToken: '',
-        displayName: nickName || '华为用户'
+        displayName: nickName || '华为用户',
+        avatarUri: avatarUri
       });
       this.saveLoginModeToPrefs('account');
       // 刷新 UI 状态

--- a/entry/src/main/ets/pages/HostListPage.ets
+++ b/entry/src/main/ets/pages/HostListPage.ets
@@ -208,8 +208,13 @@ import { RemoteProtocol } from '../services/RemoteSessionState';
 import {
   RustDeskProPreflightState,
   rustDeskProPeerIdForConnection,
-  shouldOpenRustDeskProPreflight
+  shouldOpenRustDeskProPreflight,
+  resolveRustDeskProSession,
+  rustDeskProLoginHint,
+  RustDeskProSessionResolution,
+  RustDeskProSessionState
 } from '../services/RustDeskProConnectionPreflightPolicy';
+import { RustDeskProCredentialStore } from '../services/RustDeskProCredentialStore';
 import { shouldFallbackToNativeRdpConnectionAfterResolverFailure } from '../services/RdpCertificatePreflightPolicy';
 import {
   nextConnectionAttemptGeneration,
@@ -375,6 +380,9 @@ struct HostListPage {
   @State rustDeskProRememberPassword: boolean = true;
   @State rustDeskProPreflightError: string = '';
   private rustDeskProPreflightGeneration: number = 0;
+  // Whether this attempt carried a Server Pro token, so an account-control
+  // rejection can be reported as "log in again" instead of a raw server string.
+  private rustDeskProSessionState: RustDeskProSessionState = 'not_configured';
   // RustDesk preflight Sheet 退出动画完成前，不允许复用同一 bindSheet 宿主。
   private rustDeskProPreflightClosing: boolean = false;
   private rustDeskProPreflightClosingHostId: string = '';
@@ -3099,6 +3107,19 @@ struct HostListPage {
       host.rustdeskDirectHost,
       host.rustdeskDirectPort
     );
+    // 这个 Sheet 才是真正发起 RustDesk 连接的地方（成功后才路由到 RemoteDesktop），
+    // 所以 Server Pro 会话 token 必须在这里就带上，否则开启账号访问控制的 hbbs 会以
+    // "You have not logged in or your login session has expired" 拒绝 PunchHoleRequest。
+    const proStore = RustDeskProCredentialStore.getInstance();
+    proStore.init(getContext(this) as common.Context);
+    const proSession: RustDeskProSessionResolution = resolveRustDeskProSession(
+      proStore.getAll(), host.rustdeskProAccountId, host.rustdeskAccountId,
+      host.rustdeskRelayId, direct);
+    this.rustDeskProSessionState = proSession.state;
+    hilog.info(0x0001, 'HostList', 'RustDesk Pro session state=' + proSession.state +
+      ' token=' + (proSession.token.length > 0 ? 'present' : 'absent') +
+      ' accounts=' + proStore.getAll().length.toString() +
+      ' relayBound=' + (host.rustdeskRelayId.length > 0 ? 'yes' : 'no'));
     return {
       protocol: 'rustdesk',
       host: endpoint.host,
@@ -3116,7 +3137,8 @@ struct HostListPage {
       rdAuthMode: rustDeskAuthModeForConnection(direct, host.rustdeskAuthMode) === 'request_approval' ? 1 : 0,
       rdRelayId: host.rustdeskRelayId, rdAccountId: host.rustdeskAccountId,
       rdServerKey: relay ? relay.key : '',
-      rdServerKeyMode: relay ? rustDeskRelayKeyModeForFfi(relay.key, relay.keyMode) : 1
+      rdServerKeyMode: relay ? rustDeskRelayKeyModeForFfi(relay.key, relay.keyMode) : 1,
+      rdProAccessToken: proSession.token
     };
   }
 
@@ -3179,6 +3201,8 @@ struct HostListPage {
         }
         if (state === 4 || state === 0) {
           const detail: string = this.loader.getRustDeskLastError() || this.loader.getConnectionLastMessage(sid);
+          const proHint: string = rustDeskProLoginHint(detail, this.rustDeskProSessionState);
+          if (proHint.length > 0) { throw new Error(proHint); }
           throw new Error(detail || '远端鉴权失败，请检查密码后重试。');
         }
         await new Promise<void>((resolve: () => void): void => { setTimeout(resolve, 100); });

--- a/entry/src/main/ets/pages/LoginPage.ets
+++ b/entry/src/main/ets/pages/LoginPage.ets
@@ -55,12 +55,48 @@ struct LoginPage {
       setTimeout(() => { this.enterMainPage(); }, 50);
       return;
     }
-    // 已登录账号 → 静默恢复会话 (不弹窗)
+    // 已登录账号 → 优先用本机持久化凭据恢复会话。
+    // 系统杀掉后台后进程是冷启动，AuthService 是纯内存态，只靠 HMS 静默授权
+    // 恢复会不稳定 (8 秒超时 / 返回空凭据都会把用户打回登录页)。凭据本来就
+    // 已经写在 AccountKitCreds 里，只是从来没有人读回来。
     if (!forceShow && savedMode === 'account') {
+      const restored: boolean = this.restoreLocalSession();
+      if (restored) {
+        this.enterMainPage();
+        return;
+      }
       this.trySilentLogin();  // 异步 - 成功跳转, 失败设置 checkingLogin=false 显示登录UI
       return;                 // checkingLogin 保持 true, 避免登录页闪现
     }
     this.checkingLogin = false;
+  }
+
+  /**
+   * 用本机持久化的华为账号凭据恢复内存会话。
+   *
+   * 这里只恢复 App 自己的登录态；HMS 侧的授权码/令牌刷新仍由需要它的调用方
+   * (云同步 / 设置页) 各自触发，登录页不再为此阻塞冷启动。
+   */
+  private restoreLocalSession(): boolean {
+    try {
+      const accountKit: AccountKitService = AccountKitService.getInstance();
+      accountKit.initSync(getContext(this));
+      if (!accountKit.isAuthorized()) {
+        hilog.info(0x0001, 'LoginDebug', '本机无持久化凭据，回退 HMS 静默登录');
+        return false;
+      }
+      this.auth.setLoginResult(
+        accountKit.getUnionID(),
+        accountKit.getDisplayName() || '华为用户',
+        accountKit.getAvatarUri(),
+        accountKit.getOpenID()
+      );
+      hilog.info(0x0001, 'LoginDebug', '本机凭据恢复登录态成功');
+      return true;
+    } catch (err) {
+      hilog.warn(0x0001, 'LoginDebug', '本机凭据恢复失败: ' + JSON.stringify(err));
+      return false;
+    }
   }
 
   /** 检测是否首次启动 (含卸载重装), 是则清除残留登录态 */
@@ -212,9 +248,12 @@ struct LoginPage {
       '[ACCOUNT-DEBUG] AGC_Auth_unionID=' + unionId + '  openID=' + openId);
 
     this.auth.setLoginResult(unionId, displayName, avatarUri, openId);
-    AccountKitService.getInstance().saveCredential({
+    const accountKit: AccountKitService = AccountKitService.getInstance();
+    // 未初始化时 saveCredential 会静默丢弃，冷启动就再也恢复不出登录态。
+    accountKit.initSync(getContext(this));
+    accountKit.saveCredential({
       unionID: unionId, openID: openId, authorizationCode: authCode,
-      idToken: '', displayName: displayName
+      idToken: '', displayName: displayName, avatarUri: avatarUri
     });
     this.saveLoginMode('account');
     if (showToast) {

--- a/entry/src/main/ets/pages/RemoteDesktop.ets
+++ b/entry/src/main/ets/pages/RemoteDesktop.ets
@@ -1880,7 +1880,7 @@ struct RemoteDesktop {
       return resolvedY;
     }
     const modifierY: number = this.modifierPanelVisible ? this.modifierPanelY : this.handleY;
-    const modifierHeight: number = this.modifierPanelVisible ? (this.fnLayer ? 300 : 136) :
+    const modifierHeight: number = this.modifierPanelVisible ? this.modifierPanelHeight() :
       MODIFIER_HANDLE_HEIGHT;
     const dockBottom: number = resolvedY + this.rustDeskDiagnosticsDockHeight();
     const modifierBottom: number = modifierY + modifierHeight;
@@ -1949,6 +1949,17 @@ struct RemoteDesktop {
     return Math.max(8, Math.min(x, maxX));
   }
 
+  /**
+   * 修饰键面板的估算高度，用于夹取和与诊断浮窗的避让。
+   *
+   * 必须跟着 RemoteModifierPanel 的行数走：标题栏 + 修饰键行 + 动作键行 +
+   * 方向键行，展开 Fn 层再加五行。原来四处写死 `fnLayer ? 300 : 136`，加一行
+   * 就得改四个地方，很容易漏。
+   */
+  private modifierPanelHeight(): number {
+    return this.fnLayer ? 340 : 176;
+  }
+
   private clampModifierPanelY(y: number, estimatedHeight: number): number {
     const screenH: number = this.surfaceHeight > 0 ? this.surfaceHeight : 640;
     const bottomMargin: number = this.kbHeight > 0 ? this.kbHeight + 8 : 24;
@@ -1964,7 +1975,7 @@ struct RemoteDesktop {
     const screenW: number = this.surfaceWidth > 0 ? this.surfaceWidth : 360;
     const panelW: number = this.modifierPanelWidth();
     const defaultX: number = this.handleSide === 'right' ? Math.max(8, screenW - panelW - 8) : 8;
-    const defaultY: number = this.clampModifierPanelY(this.handleY - 20, this.fnLayer ? 300 : 136);
+    const defaultY: number = this.clampModifierPanelY(this.handleY - 20, this.modifierPanelHeight());
     this.modifierPanelX = this.clampModifierPanelX(defaultX);
     this.modifierPanelY = defaultY;
     this.shortcutPanelX = this.modifierPanelX;
@@ -1974,14 +1985,14 @@ struct RemoteDesktop {
 
   private clampModifierPanelsIntoView(): void {
     this.modifierPanelX = this.clampModifierPanelX(this.modifierPanelX);
-    this.modifierPanelY = this.clampModifierPanelY(this.modifierPanelY, this.fnLayer ? 300 : 136);
+    this.modifierPanelY = this.clampModifierPanelY(this.modifierPanelY, this.modifierPanelHeight());
     this.shortcutPanelX = this.clampModifierPanelX(this.shortcutPanelX);
     this.shortcutPanelY = this.clampModifierPanelY(this.shortcutPanelY, 238);
   }
 
   private moveModifierPanel(x: number, y: number): void {
     this.modifierPanelX = this.clampModifierPanelX(x);
-    this.modifierPanelY = this.clampModifierPanelY(y, this.fnLayer ? 300 : 136);
+    this.modifierPanelY = this.clampModifierPanelY(y, this.modifierPanelHeight());
   }
 
   private moveShortcutPanel(x: number, y: number): void {

--- a/entry/src/main/ets/pages/RemoteDesktop.ets
+++ b/entry/src/main/ets/pages/RemoteDesktop.ets
@@ -84,6 +84,10 @@ import {
   shouldUseSystemMousePointer
 } from '../services/RemotePointerModePolicy';
 import {
+  nextTwoFingerScrollLatch,
+  twoFingerSpreadVp
+} from '../services/TwoFingerScrollPolicy';
+import {
   normalizeRemoteCursorStyle,
   remoteCursorSnapshotChanged,
   RemoteCursorStyle,
@@ -740,6 +744,10 @@ struct RemoteDesktop {
   private directTouchPressScheduledAtMs: number = 0;
   /** touchStartLocalX/Y 这个重心锚点是按几根手指算的；数量变了必须重锚。 */
   private touchAnchorFingerCount: number = 0;
+  /** 触控模式：本次双指手势已判定为滚轮，锁定到手指全部抬起。 */
+  private touchTwoFingerScrollActive: boolean = false;
+  /** 上一帧的两指间距 (vp)，用来把捏合从滚动里区分出来。 */
+  private touchTwoFingerSpread: number = 0;
   // 为了让输入光标避开软键盘而额外施加的画布上移量 (px)
   private keyboardCanvasLiftPx: number = 0;
   private lastTouchMs: number = 0;
@@ -1534,6 +1542,12 @@ struct RemoteDesktop {
   }
 
   private startCanvasPinch(event: GestureEvent): void {
+    if (this.touchTwoFingerScrollActive) {
+      // 本次双指已经被 onTouch 认定为滚轮。此时 claim 输入会让 onTouch 再也
+      // 收不到 Move，滚动会在半途变成缩放；直接放弃这次捏合。
+      hilog.info(RD_DOMAIN, RD_TAG, 'canvas pinch skipped: two-finger scroll owns gesture');
+      return;
+    }
     if (this.shouldUseRustDeskRemoteAppTouchScale()) {
       this.claimCanvasPinchInput();
       this.startRustDeskRemoteAppTouchScale(event);
@@ -4612,6 +4626,8 @@ struct RemoteDesktop {
       if (this.keyboardCanvasLiftPx !== 0) {
         this.keyboardCanvasLiftPx = 0;
         this.applyCanvasTransform();
+        // 让位复位只改了变换，不补一帧的话空出来的区域会一直是黑的。
+        this.repaintAfterCanvasTransform('keyboard-lift-reset');
         hilog.info(RD_DOMAIN, RD_TAG, 'keyboard-lift reset reason=' + reason);
       }
       return;
@@ -4636,6 +4652,30 @@ struct RemoteDesktop {
       ' kb=' + Math.round(keyboardHeightPx).toString() +
       ' lift=' + Math.round(this.keyboardCanvasLiftPx).toString() +
       ' sign=' + KEYBOARD_LIFT_SIGN.toString());
+  }
+
+  /**
+   * 画布变换改变后强制重绘一次。
+   *
+   * GLRenderer::SetCanvasTransform 只更新变换和视口快照，屏幕要等下一帧
+   * RenderFrame/RenderRawBGRA 才会用新变换重画。远端画面静止时（RustDesk
+   * 尤其明显）根本不会有下一帧，于是软键盘收起后让位留下的黑边会一直挂着，
+   * 直到远端自己有变化。这里复用前台恢复路径的两级刷新：先用 RDP 的本地
+   * 缓存帧立刻补画，再请求远端推一帧。
+   */
+  private repaintAfterCanvasTransform(reason: string): void {
+    if (!this.connected || this.sessionId <= 0 || this.rendererHandle <= 0) {
+      return;
+    }
+    try {
+      const presented: boolean = this.loader.presentRdpCachedFrame(this.sessionId);
+      this.loader.requestFrameRefresh();
+      hilog.info(RD_DOMAIN, RD_TAG, 'canvas-repaint reason=' + reason +
+        ' cached=' + (presented ? '1' : '0'));
+    } catch (err) {
+      hilog.warn(RD_DOMAIN, RD_TAG,
+        'canvas-repaint failed reason=' + reason + ' ' + JSON.stringify(err));
+    }
   }
 
   private startRemoteCursorPolling(sessionId: number): void {
@@ -7046,6 +7086,7 @@ struct RemoteDesktop {
     if (this.keyboardCanvasLiftPx !== 0) {
       this.keyboardCanvasLiftPx = 0;
       this.applyCanvasTransform();
+      this.repaintAfterCanvasTransform('keyboard-close-' + source);
     }
     this.resetRemoteImeSession('closed-' + source);
     this.keyboardSubmitRefocusPending = false;
@@ -7432,6 +7473,8 @@ struct RemoteDesktop {
     }
     this.touchFingerCount = 0;
     this.touchAnchorFingerCount = 0;
+    this.touchTwoFingerScrollActive = false;
+    this.touchTwoFingerSpread = 0;
     this.touchDragActive = false;
     this.touchDragPending = false;
     this.touchMoved = false;
@@ -7550,6 +7593,32 @@ struct RemoteDesktop {
     hilog.info(RD_DOMAIN, RD_TAG,
       'touchpad-scroll delta=' + sendDelta.toString() + ' stepDy=' + stepDy.toString() +
         ' remote=' + this.remoteCursorX.toString() + ',' + this.remoteCursorY.toString());
+  }
+
+  /** 当前两指间距 (vp)；不足两指时返回 0。 */
+  private currentTwoFingerSpread(event: TouchEvent): number {
+    if (event.touches.length < 2) {
+      return 0;
+    }
+    return twoFingerSpreadVp(event.touches[0].x, event.touches[0].y,
+      event.touches[1].x, event.touches[1].y);
+  }
+
+  /**
+   * 触控模式的双指滚轮。
+   *
+   * 触控模式没有常驻光标，远端滚的是指针底下的那个窗口，所以必须先把远端
+   * 指针送到双指重心再发滚轮，否则会在上一次点击的位置翻页。queueMouseMove
+   * 会同步更新 remoteCursorX/Y，sendTouchPadWheel 随后读到的就是新位置。
+   */
+  private sendDirectTouchWheel(centerX: number, centerY: number, stepDy: number): void {
+    const mapped: MappedPoint = this.mapInputPoint(centerX, centerY);
+    if (!mapped.inside) {
+      return;
+    }
+    this.queueMouseMove(mapped.x, mapped.y);
+    this.flushMouseMove();
+    this.sendTouchPadWheel(stepDy);
   }
 
   private sendRemoteKeyTap(keyCode: number, label: string): void {
@@ -7848,6 +7917,10 @@ struct RemoteDesktop {
             this.touchLastLocalX = avg.x;
             this.touchLastLocalY = avg.y;
           }
+          // 加手指会让间距跳变，基线必须跟着重取，否则下一帧会被当成捏合。
+          this.touchTwoFingerSpread = this.currentTwoFingerSpread(event);
+          this.touchWheelRemainder = 0;
+          this.lastTouchWheelMs = 0;
           // 升级成多指手势：还没发出去的按下直接丢弃，已经按下的才需要释放。
           this.cancelDirectTouchPress();
           if (this.touchLeftDown) {
@@ -7875,6 +7948,7 @@ struct RemoteDesktop {
         if (this.touchMaxFingers >= 2) {
           const avg: LocalPoint | null = this.averageTouchPoint(event);
           if (avg) {
+            const spread: number = this.currentTwoFingerSpread(event);
             if (this.touchAnchorFingerCount !== event.touches.length) {
               // 触点数量变了，重心必然跳变（三指→两指→一指），这不是"手指移动了"。
               // 重新锚定，否则一次干净的三指轻点会因为手指先后抬起被误判成滑动，
@@ -7882,6 +7956,9 @@ struct RemoteDesktop {
               this.touchAnchorFingerCount = event.touches.length;
               this.touchStartLocalX = avg.x;
               this.touchStartLocalY = avg.y;
+              // 重心跳变的这一帧不能拿去算滚轮步长，同步 last 把它吃掉。
+              this.touchLastLocalX = avg.x;
+              this.touchLastLocalY = avg.y;
             } else {
               const dx: number = avg.x - this.touchStartLocalX;
               const dy: number = avg.y - this.touchStartLocalY;
@@ -7889,7 +7966,24 @@ struct RemoteDesktop {
                 this.touchMoved = true;
                 this.touchDragPending = false;
               }
+              const stepDx: number = avg.x - this.touchLastLocalX;
+              const stepDy: number = avg.y - this.touchLastLocalY;
+              // 双指纵向滑动 = 滚轮翻页。三指仍然只用于控制面板开关。
+              if (event.touches.length === 2) {
+                const wasScrolling: boolean = this.touchTwoFingerScrollActive;
+                this.touchTwoFingerScrollActive = nextTwoFingerScrollLatch(
+                  wasScrolling, stepDx, stepDy, spread - this.touchTwoFingerSpread);
+                if (this.touchTwoFingerScrollActive) {
+                  if (!wasScrolling) {
+                    hilog.info(RD_DOMAIN, RD_TAG, 'direct-touch two-finger scroll begin');
+                  }
+                  this.sendDirectTouchWheel(avg.x, avg.y, stepDy);
+                }
+              }
+              this.touchLastLocalX = avg.x;
+              this.touchLastLocalY = avg.y;
             }
+            this.touchTwoFingerSpread = spread;
           }
           return;
         }

--- a/entry/src/main/ets/pages/RemoteDesktop.ets
+++ b/entry/src/main/ets/pages/RemoteDesktop.ets
@@ -199,6 +199,13 @@ import {
   rustDeskConnectionError
 } from '../services/RustDeskHostConfigPolicy';
 import {
+  resolveRustDeskProSession,
+  rustDeskProLoginHint,
+  RustDeskProSessionResolution,
+  RustDeskProSessionState
+} from '../services/RustDeskProConnectionPreflightPolicy';
+import { RustDeskProCredentialStore } from '../services/RustDeskProCredentialStore';
+import {
   mapPhysicalKeyForRemoteLayout,
   isMacCapsLockLongPress,
   MACOS_CAPS_LOCK_LONG_PRESS_MS,
@@ -521,6 +528,9 @@ struct RemoteDesktop {
   private rustDeskAuthSheetClosing: boolean = false;
   private rustDeskAuthQueuedMessage: string | null = null;
   private rustDeskSessionAuthChoice: RustDeskAuthChoice = 'password';
+  // Whether this attempt carried a Server Pro token, so an account-control
+  // rejection can be reported as "log in again" instead of a raw server string.
+  private rustDeskProSessionState: RustDeskProSessionState = 'not_configured';
   private rustDeskSessionPassword: string = '';
   private rustDeskSessionRememberPassword: boolean = false;
   private rustDeskSessionPasswordMode: number = 0;
@@ -3947,6 +3957,10 @@ struct RemoteDesktop {
           if (ffiError.indexOf('connection cancelled') >= 0) {
             throw new Error('连接请求已取消' + detail + ' [E-RUSTDESK-CANCELLED]');
           }
+          const proHint: string = rustDeskProLoginHint(ffiError, this.rustDeskProSessionState);
+          if (proHint.length > 0) {
+            throw new Error(proHint + detail + ' [E-RUSTDESK-PRO-LOGIN]');
+          }
           throw new Error('RustDesk 握手失败或连接已断开' + detail +
             ' [E-RUSTDESK-STATE-' + state.toString() + ']');
         }
@@ -4722,6 +4736,24 @@ struct RemoteDesktop {
         }
       }
       const rustDeskDirect: boolean = host.protocol === 'rustdesk' && host.rustdeskDirectEnabled;
+      // Server Pro 开启账号访问控制时，hbbs 会拒绝没有会话 token 的 PunchHoleRequest
+      // ("You have not logged in or your login session has expired")。token 只在
+      // 本次连接的内存中传递，不写入 RemoteHost、云表或日志。
+      let rdProAccessToken: string = '';
+      this.rustDeskProSessionState = 'not_configured';
+      if (host.protocol === 'rustdesk' && !rustDeskDirect) {
+        const proStore = RustDeskProCredentialStore.getInstance();
+        proStore.init(getContext(this) as common.Context);
+        const proSession: RustDeskProSessionResolution = resolveRustDeskProSession(
+          proStore.getAll(), host.rustdeskProAccountId, host.rustdeskAccountId,
+          host.rustdeskRelayId, false);
+        rdProAccessToken = proSession.token;
+        this.rustDeskProSessionState = proSession.state;
+        hilog.info(RD_DOMAIN, RD_TAG, 'RustDesk Pro session state=' + proSession.state +
+          ' token=' + (rdProAccessToken.length > 0 ? 'present' : 'absent') +
+          ' accounts=' + proStore.getAll().length.toString() +
+          ' relayBound=' + (host.rustdeskRelayId.length > 0 ? 'yes' : 'no'));
+      }
       const directHost: string = host.rustdeskDirectHost.trim();
       if (rustDeskDirect && directHost.length === 0) {
         throw new Error('RustDesk 直连地址为空，请在主机编辑中填写局域网地址 [E-RUSTDESK-DIRECT-HOST]');
@@ -4792,7 +4824,8 @@ struct RemoteDesktop {
         rdRelayId: host.rustdeskRelayId,
         rdAccountId: host.rustdeskAccountId,
         rdServerKey: rdServerKey,
-        rdServerKeyMode: rdServerKeyMode
+        rdServerKeyMode: rdServerKeyMode,
+        rdProAccessToken: rdProAccessToken
       };
       // 编码偏好单独处理 (0=auto → 不强制)
       if (rdCodecVal > 0) {
@@ -4817,6 +4850,8 @@ struct RemoteDesktop {
         // never keep the local session-config reference alive on this side.
         cfg.rdpRestrictedAdminHash = '';
         rdpRestrictedAdminHash = '';
+        cfg.rdProAccessToken = '';
+        rdProAccessToken = '';
       }
       hilog.info(RD_DOMAIN, RD_TAG, 'NAPI connect returned: ' + sid);
       if (sid <= 0) {

--- a/entry/src/main/ets/pages/RemoteDesktop.ets
+++ b/entry/src/main/ets/pages/RemoteDesktop.ets
@@ -181,6 +181,11 @@ import {
   RemoteImeCommandKind,
   RemoteImeCommandQueue
 } from '../services/RemoteImeCommandQueue';
+import {
+  KEYBOARD_CARET_MARGIN_VP,
+  keyboardCanvasLiftDeltaPx,
+  maxKeyboardCanvasLiftPx
+} from '../services/RemoteKeyboardAvoidPolicy';
 import { hashForLog, maskHost, maskUser, safeError } from '../utils/SafeLogger';
 import {
   LocalResourceStats,
@@ -232,6 +237,30 @@ const TOUCHPAD_SCROLL_GAIN = 0.08;
 const TOUCHPAD_SCROLL_FLUSH_MS = 24;
 const TOUCHPAD_SCROLL_MAX_DELTA = 2;
 const TOUCH_DIRECT_RIGHT_CLICK_MS = 650;
+/**
+ * 触控模式下从"移动光标"到"按下左键"之间的间隔。
+ *
+ * 远端 Windows 的任务栏、菜单这类控件要先收到 mouse-enter/hover 才会响应
+ * 点击。光标瞬移过去的同一毫秒就按下，控件还没处理完悬停，点击会被吞掉，
+ * 用户看到的就是"鼠标只是挪了一下"。真实鼠标总有移动轨迹，不存在这个问题。
+ */
+const DIRECT_TOUCH_PRESS_DELAY_MS = 40;
+/**
+ * 画布让位方向。
+ *
+ * gl_renderer.cpp:977 是 `vpY = (height_ - vpH)/2 + canvasPanY_`，按 glViewport
+ * 的 y 从底边算起推导应该取正值；但实测画面是往下掉的，说明纹理采样这一路有
+ * 翻转，实际需要负值才能把画面推向上方。以实测为准。
+ */
+const KEYBOARD_LIFT_SIGN = -1;
+/**
+ * 悬浮胶囊几何 — 必须和 RemoteModifierHandle.ets 里的同名常量保持一致。
+ * 吸边/夹取算法在这边，实际绘制在那边，两处对不上胶囊就会被切掉或错位。
+ */
+const MODIFIER_HANDLE_WIDTH = 48;
+const MODIFIER_HANDLE_VISIBLE_WIDTH = 34;
+const MODIFIER_HANDLE_HEIGHT = 30;
+const MODIFIER_HANDLE_KEY_BUTTON_BLOCK = 50;
 const REMOTE_IME_SELECTION_ACK_TIMEOUT_MS = 600;
 const REMOTE_IME_COMMAND_RETRY_MS = 50;
 const INPUT_LOG_SAMPLE_MS = 1000;
@@ -695,12 +724,24 @@ struct RemoteDesktop {
   private keyboardProgrammaticSelection: boolean = false;
   private keyboardSelectionAckTimer: number = -1;
   private keyboardCommandQueue: RemoteImeCommandQueue = new RemoteImeCommandQueue();
+  /** 影子 TextArea 当前是否持有焦点；只有真的被抢走时才补发 requestFocus。 */
+  private keyboardProxyFocused: boolean = false;
   private keyboardCommandPumpTimer: number = -1;
   private touchIndicatorTimer: number = -1;
   private kbWin: window.Window | null = null;
   private kbAvoidCb: ((data: window.AvoidAreaOptions) => void) | null = null;
   private touchHoldDragTimer: number = -1;
   private touchDirectRightClickTimer: number = -1;
+  // 触控模式的延迟按下（见 DIRECT_TOUCH_PRESS_DELAY_MS）
+  private directTouchPressTimer: number = -1;
+  private directTouchPressPending: boolean = false;
+  private directTouchPressX: number = 0;
+  private directTouchPressY: number = 0;
+  private directTouchPressScheduledAtMs: number = 0;
+  /** touchStartLocalX/Y 这个重心锚点是按几根手指算的；数量变了必须重锚。 */
+  private touchAnchorFingerCount: number = 0;
+  // 为了让输入光标避开软键盘而额外施加的画布上移量 (px)
+  private keyboardCanvasLiftPx: number = 0;
   private lastTouchMs: number = 0;
   private inputLogCount: number = 0;
   private lastInputLogMs: number = 0;
@@ -1435,8 +1476,11 @@ struct RemoteDesktop {
     }
     const viewport: CanvasViewport = this.currentCanvasViewport();
     this.canvasTransform = clampCanvasTransform(this.canvasTransform, viewport);
+    // 软键盘让位量叠加在 clamp 之后：贴合缩放时 maxPanY 为 0，写进
+    // canvasTransform 会被夹掉，只能在提交给渲染器的这一步补上。
     this.loader.setRendererCanvasTransform(this.rendererHandle, this.canvasTransform.scale,
-      this.canvasTransform.panX, this.canvasTransform.panY);
+      this.canvasTransform.panX,
+      this.canvasTransform.panY + KEYBOARD_LIFT_SIGN * this.keyboardCanvasLiftPx);
     this.invalidateRendererViewportCache();
   }
 
@@ -1721,9 +1765,12 @@ struct RemoteDesktop {
     const midX: number = screenW / 2;
     const newSide: string = x + capsuleHalfW < midX ? 'left' : 'right';
     const snapX: number = newSide === 'left' ? this.modifierHiddenLeftX() : this.modifierHiddenRightX(screenW);
-    const topMargin: number = 48;
+    // 胶囊正上方还挂着键盘快捷按钮 (44 高 + 6 间隔)，顶部余量必须留得下它，
+    // 否则贴到顶边时按钮会被切掉。
+    const topMargin: number = MODIFIER_HANDLE_KEY_BUTTON_BLOCK + 6;
     const bottomMargin: number = this.kbHeight > 0 ? this.kbHeight + 8 : 48;
-    const clampedY: number = Math.max(topMargin, Math.min(y, screenH - bottomMargin - 42));
+    const clampedY: number = Math.max(topMargin,
+      Math.min(y, screenH - bottomMargin - MODIFIER_HANDLE_HEIGHT));
     this.handleX = x;
     this.handleY = clampedY;
     animateTo({ duration: 180, curve: Curve.EaseOut }, (): void => {
@@ -1746,16 +1793,21 @@ struct RemoteDesktop {
     const yRatio: number = (savedYR > 0 && savedYR < 1) ? savedYR : 0.35;
     this.handleSide = side;
     this.handleX = side === 'left' ? this.modifierHiddenLeftX() : this.modifierHiddenRightX(screenW);
-    this.handleY = Math.round(screenH * yRatio);
+    // 恢复位置也要夹一次：旧版本存下来的比例可能贴得太靠上，会把胶囊上方的
+    // 键盘按钮切掉。
+    const topMargin: number = MODIFIER_HANDLE_KEY_BUTTON_BLOCK + 6;
+    const bottomMargin: number = this.kbHeight > 0 ? this.kbHeight + 8 : 48;
+    this.handleY = Math.max(topMargin,
+      Math.min(Math.round(screenH * yRatio), screenH - bottomMargin - MODIFIER_HANDLE_HEIGHT));
     this.ensureModifierPanelPositions();
   }
 
   private modifierHandleWidth(): number {
-    return 58;
+    return MODIFIER_HANDLE_WIDTH;
   }
 
   private modifierHandleVisibleWidth(): number {
-    return 24;
+    return MODIFIER_HANDLE_VISIBLE_WIDTH;
   }
 
   private modifierHiddenLeftX(): number {
@@ -1828,7 +1880,8 @@ struct RemoteDesktop {
       return resolvedY;
     }
     const modifierY: number = this.modifierPanelVisible ? this.modifierPanelY : this.handleY;
-    const modifierHeight: number = this.modifierPanelVisible ? (this.fnLayer ? 300 : 136) : 42;
+    const modifierHeight: number = this.modifierPanelVisible ? (this.fnLayer ? 300 : 136) :
+      MODIFIER_HANDLE_HEIGHT;
     const dockBottom: number = resolvedY + this.rustDeskDiagnosticsDockHeight();
     const modifierBottom: number = modifierY + modifierHeight;
     if (dockBottom + 12 <= modifierY || resolvedY >= modifierBottom + 12) {
@@ -1934,6 +1987,26 @@ struct RemoteDesktop {
   private moveShortcutPanel(x: number, y: number): void {
     this.shortcutPanelX = this.clampModifierPanelX(x);
     this.shortcutPanelY = this.clampModifierPanelY(y, 238);
+  }
+
+  /**
+   * 会话进入可交互状态后必须出现的界面入口。
+   *
+   * 悬浮胶囊是平板触控模式下**唯一常驻可见**的键盘/修饰键入口：RustDesk 顶栏
+   * 只在桌面设备或键鼠模式下显示 (shouldShowRustDeskTopBar)，控制面板又只能
+   * 三指轻点唤出。预鉴权交接路径 (doBackgroundRestoreRender) 以前漏了这一步，
+   * 结果远端画面正常出图、却没有任何可见的输入入口。两条连接路径必须共用这个
+   * 方法，不能再各写一份。
+   */
+  private showConnectedSessionControls(protocol: string): void {
+    this.initHandlePosition();
+    this.handleVisible = true;
+    if (protocol === 'rustdesk' && this.rustdeskShowDiagnostics) {
+      this.initRustDeskDiagnosticsDock();
+    }
+    this.promptPhysicalKeyboardLayout();
+    hilog.info(RD_DOMAIN, RD_TAG, 'session-controls shown protocol=' + protocol +
+      ' handle=1 topBar=' + (this.shouldShowRustDeskSessionTopBar() ? '1' : '0'));
   }
 
   private openModifierPanel(): void {
@@ -2197,6 +2270,9 @@ struct RemoteDesktop {
           if (data.type === window.AvoidAreaType.TYPE_KEYBOARD) {
             this.kbHeight = px2vp(data.area.bottomRect.height);
             this.updateRustDeskDiagnosticsDockForKeyboard();
+            // 软键盘升起/收起都要重新算画布让位量；收起时 kbHeight 归零，
+            // updateKeyboardCanvasLift 会把偏移清掉并还原画面。
+            this.updateKeyboardCanvasLift('keyboard-avoid-area');
             hilog.info(RD_DOMAIN, RD_TAG,
               'kbHeight changed: ' + Math.round(this.kbHeight).toString() + 'vp');
           }
@@ -3856,6 +3932,13 @@ struct RemoteDesktop {
     if (x !== this.remoteCursorX || y !== this.remoteCursorY) {
       this.rememberRemoteCursor(x, y);
     }
+    // 位置守卫：远端只在 MOUSE_TYPE_MOVE 时移动光标，DOWN/UP 分支完全忽略
+    // 事件里的 x/y (上游 server/input_service.rs 的 handle_mouse_)，按键落在
+    // 光标当前所在位置。所以每个按键事件前都必须先把光标挪到目标坐标，
+    // 否则第一次轻点会点在上一次的位置上 —— 表现就是"第一下只把光标挪过去、
+    // 第二下才真的点中"。queueMouseMove 的定时器 flush 赶不上同一次轻点的
+    // DOWN/UP，必须在这里同步补发。
+    this.queueMouseMove(x, y, false);
     this.flushMouseMove();
     if (!this.canForwardInput('mouseButton')) {
       return;
@@ -4476,6 +4559,10 @@ struct RemoteDesktop {
       this.remoteCursorNativeVisible = snapshot.visible || this.isRustDeskSession();
       this.requestRemoteCursorViewRefresh(true);
     }
+    if (positionChanged && this.kbHeight > 0) {
+      // 光标在远端移动 (例如换了个输入框) 后重新算让位量。
+      this.updateKeyboardCanvasLift('cursor-move');
+    }
     if (shapeChanged || positionChanged || visibilityChanged ||
       this.remoteCursorLastLogMs === 0 || now - this.remoteCursorLastLogMs >= REMOTE_CURSOR_LOG_SAMPLE_MS) {
       this.remoteCursorLastLogMs = now;
@@ -4495,6 +4582,49 @@ struct RemoteDesktop {
         ' observed=' + this.remoteCursorMotion.remoteObservedX.toFixed(1) + ',' +
         this.remoteCursorMotion.remoteObservedY.toFixed(1));
     }
+  }
+
+  /**
+   * 让远端输入光标露出在软键盘上方。
+   *
+   * 直接把偏移叠加在 setRendererCanvasTransform 的 panY 上，而不是写进
+   * canvasTransform：贴合缩放 (scale=1) 时 clampCanvasTransform 的 maxPanY 是 0，
+   * 存进去会立刻被夹掉。输入映射走 readRendererViewport 读真实视口，所以画面
+   * 上移后触摸坐标会自动跟着走，不需要另外补偿。
+   */
+  private updateKeyboardCanvasLift(reason: string): void {
+    if (this.rendererHandle <= 0) {
+      return;
+    }
+    const keyboardHeightPx: number = this.vpToPx(this.kbHeight);
+    if (!this.connected || keyboardHeightPx <= 0) {
+      if (this.keyboardCanvasLiftPx !== 0) {
+        this.keyboardCanvasLiftPx = 0;
+        this.applyCanvasTransform();
+        hilog.info(RD_DOMAIN, RD_TAG, 'keyboard-lift reset reason=' + reason);
+      }
+      return;
+    }
+    const caret: LocalPoint = this.remoteToLocalPoint(this.remoteCursorX, this.remoteCursorY);
+    const surfaceHeightPx: number = this.renderHeightPx > 0 ? this.renderHeightPx :
+      this.vpToPx(this.surfaceHeight);
+    const deltaPx: number = keyboardCanvasLiftDeltaPx(this.vpToPx(caret.y), surfaceHeightPx,
+      keyboardHeightPx, this.vpToPx(KEYBOARD_CARET_MARGIN_VP));
+    if (deltaPx <= 0) {
+      return;
+    }
+    const nextLift: number = Math.min(this.keyboardCanvasLiftPx + deltaPx,
+      maxKeyboardCanvasLiftPx(surfaceHeightPx, keyboardHeightPx));
+    if (Math.abs(nextLift - this.keyboardCanvasLiftPx) < 1) {
+      return;
+    }
+    this.keyboardCanvasLiftPx = nextLift;
+    this.applyCanvasTransform();
+    hilog.info(RD_DOMAIN, RD_TAG, 'keyboard-lift reason=' + reason +
+      ' caretY=' + Math.round(this.vpToPx(caret.y)).toString() +
+      ' kb=' + Math.round(keyboardHeightPx).toString() +
+      ' lift=' + Math.round(this.keyboardCanvasLiftPx).toString() +
+      ' sign=' + KEYBOARD_LIFT_SIGN.toString());
   }
 
   private startRemoteCursorPolling(sessionId: number): void {
@@ -4898,12 +5028,7 @@ struct RemoteDesktop {
       await this.prepareRemoteSessionPipForForeground(host, sid);
       this.persistRustDeskSessionAuth(host);
       // T-171: 连接成功后显示悬浮胶囊
-      this.initHandlePosition();
-      this.handleVisible = true;
-      if (host.protocol === 'rustdesk' && this.rustdeskShowDiagnostics) {
-        this.initRustDeskDiagnosticsDock();
-      }
-      this.promptPhysicalKeyboardLayout();
+      this.showConnectedSessionControls(host.protocol);
       if (host.protocol === 'rdp') {
         this.startRdpRenderWatchdog(sid, attemptId);
         this.startRdpNativeStateMonitor(sid, attemptId);
@@ -5772,6 +5897,24 @@ struct RemoteDesktop {
         this.inputForwardReady = true;
         this.scheduleRemoteInputFocus('background-preauthenticated');
         this.activeSessionRegistry.markRenderAttached(surfaceId);
+        // Pro 主机在列表页完成鉴权后走的是这条交接路径，不是 connect-success。
+        // 少了这一句，画面出来了但悬浮胶囊不显示，平板触控模式下就完全没有
+        // 打开虚拟键盘的入口。
+        this.showConnectedSessionControls('rustdesk');
+        // connect-success 里做、这条交接路径漏掉的两件事。其余收尾动作
+        // (认证方式落盘 / 活动会话登记) 由 HostListPage 的预检完成，横屏由
+        // aboutToAppear 设置，都不要在这里重复。
+        if (this.pendingHost !== null) {
+          this.srv.updateLastConnected(this.pendingHost.id).catch((err: Error): void => {
+            hilog.warn(RD_DOMAIN, RD_TAG, 'preauthenticated: updateLastConnected failed ' +
+              (err.message ? err.message : JSON.stringify(err)));
+          });
+        }
+        if (this.clipboardBridge === null) {
+          this.startClipboardBridgeBestEffort(this.sessionId, this.connectAttemptId,
+            clipboardSyncEnabledForProtocol('rustdesk',
+              AppStorage.get<boolean>('rdpClipboardEnabled') ?? true, this.rustdeskClipboardEnabled));
+        }
         this.setRemoteKeepScreenOn(true);
         this.setRemoteNavigationHidden(true, 'preauthenticated-session-handoff');
         this.loader.requestFrameRefresh();
@@ -6101,6 +6244,49 @@ struct RemoteDesktop {
       hilog.info(RD_DOMAIN, RD_TAG, 'one-finger hold drag start remote=' +
       this.remoteCursorX.toString() + ',' + this.remoteCursorY.toString());
     }, TOUCH_DRAG_HOLD_MS);
+  }
+
+  /**
+   * 触控模式：光标已经移到目标点，延迟一小段时间再按下左键。
+   *
+   * 见 DIRECT_TOUCH_PRESS_DELAY_MS —— 让远端控件有机会先处理 hover。
+   * touchLeftDown 只有在 DOWN 真正发出去之后才置位，否则手势中途升级成
+   * 多指时会留下一个没有配对 DOWN 的 UP。
+   */
+  private scheduleDirectTouchPress(x: number, y: number): void {
+    this.cancelDirectTouchPress();
+    this.directTouchPressX = x;
+    this.directTouchPressY = y;
+    this.directTouchPressPending = true;
+    this.directTouchPressScheduledAtMs = Date.now();
+    this.directTouchPressTimer = setTimeout((): void => {
+      this.directTouchPressTimer = -1;
+      this.flushDirectTouchPress();
+    }, DIRECT_TOUCH_PRESS_DELAY_MS);
+  }
+
+  /** 抬手或开始拖动前必须调用：保证 DOWN 一定早于 UP 和后续移动。 */
+  private flushDirectTouchPress(): void {
+    if (!this.directTouchPressPending) {
+      return;
+    }
+    const hoverMs: number = Date.now() - this.directTouchPressScheduledAtMs;
+    this.cancelDirectTouchPress();
+    this.touchLeftDown = true;
+    this.sendMouseNow(this.directTouchPressX, this.directTouchPressY, 0, true);
+    // 这条不走 logMappedInput 的采样限流，用于核对 MOVE→DOWN 的真实间隔。
+    hilog.info(RD_DOMAIN, RD_TAG, 'direct-touch press remote=' +
+      this.directTouchPressX.toString() + ',' + this.directTouchPressY.toString() +
+      ' hoverMs=' + hoverMs.toString());
+  }
+
+  /** 丢弃还没发出去的按下（手势升级为多指、或触摸被系统取消）。 */
+  private cancelDirectTouchPress(): void {
+    this.directTouchPressPending = false;
+    if (this.directTouchPressTimer >= 0) {
+      clearTimeout(this.directTouchPressTimer);
+      this.directTouchPressTimer = -1;
+    }
   }
 
   private startDirectTouchRightClickTimer(): void {
@@ -6789,18 +6975,67 @@ struct RemoteDesktop {
     this.keyboardOpen = true;
     this.startRemoteImeSession();
     hilog.info(RD_DOMAIN, RD_TAG, 'kbd-open');
-    try {
-      const focused: boolean = focusControl.requestFocus('RemoteDesktopKeyboard');
-      hilog.info(RD_DOMAIN, RD_TAG, 'kbd-open-focus editor=' + (focused ? '1' : '0'));
-    } catch (err) {
-      hilog.error(RD_DOMAIN, RD_TAG,
-        'openKeyboard focus failed: ' + JSON.stringify(err));
+    // 影子 TextArea 的 enableKeyboardOnFocus 绑定 keyboardOpen，而属性更新要等
+    // 到本次事件回调结束后的重绘才生效。同步请求焦点会在属性仍是 false 时命中，
+    // 编辑器拿到焦点但系统输入法不会弹出。必须等一帧再请求。
+    setTimeout((): void => {
+      if (!this.keyboardOpen) {
+        return;
+      }
+      try {
+        const focused: boolean = focusControl.requestFocus('RemoteDesktopKeyboard');
+        hilog.info(RD_DOMAIN, RD_TAG, 'kbd-open-focus editor=' + (focused ? '1' : '0'));
+      } catch (err) {
+        hilog.error(RD_DOMAIN, RD_TAG,
+          'openKeyboard focus failed: ' + JSON.stringify(err));
+      }
+    }, 50);
+  }
+
+  /**
+   * 把系统输入法焦点交还给隐藏的影子 TextArea。
+   *
+   * 远端画布层 (remoteInputSurface / XComponent) 是可获焦节点，任何一次画布
+   * 点击都可能把焦点从影子 TextArea 抢走；TextArea 一旦退出编辑态，
+   * onEditChange(false) 就会走 markKeyboardClosed，软键盘立刻收起 —— 用户
+   * 就永远无法"点开远端输入框再打字"。
+   */
+  private restoreVirtualKeyboardFocus(source: string): void {
+    if (!this.keyboardOpen) {
+      return;
     }
+    setTimeout((): void => {
+      if (!this.keyboardOpen || this.keyboardProxyFocused) {
+        return;
+      }
+      try {
+        const focused: boolean = focusControl.requestFocus('RemoteDesktopKeyboard');
+        hilog.info(RD_DOMAIN, RD_TAG,
+          'kbd-refocus source=' + source + ' editor=' + (focused ? '1' : '0'));
+      } catch (err) {
+        hilog.warn(RD_DOMAIN, RD_TAG,
+          'kbd-refocus failed source=' + source + ' ' + JSON.stringify(err));
+      }
+    }, 0);
   }
 
   private markKeyboardClosed(source: string): void {
     this.keyboardOpen = false;
     this.hardwareKeyboardProxyActive = false;
+    // 必须显式结束编辑态。只把焦点移走是不可靠的：requestFocus 对画布层会
+    // 失败 (日志里出现过 overlay=0 xcomponent=0)，那时焦点仍留在影子 TextArea
+    // 上、系统键盘不收，而 keyboardOpen 已经翻成 false，下一次点击就又去开键盘，
+    // 表现为"键盘按钮只能开、不能关"。
+    try {
+      this.keyboardController.stopEditing();
+    } catch (_err) {
+      // TextArea 尚未挂载或本来就不在编辑态时无需处理。
+    }
+    // 兜底还原画布：avoidAreaChange 不一定在每种收起路径上都回调。
+    if (this.keyboardCanvasLiftPx !== 0) {
+      this.keyboardCanvasLiftPx = 0;
+      this.applyCanvasTransform();
+    }
     this.resetRemoteImeSession('closed-' + source);
     this.keyboardSubmitRefocusPending = false;
     hilog.info(RD_DOMAIN, RD_TAG, 'kbd-close source=' + source);
@@ -6813,8 +7048,9 @@ struct RemoteDesktop {
     if (!this.keyboardOpen) {
       return;
     }
+    // 键盘本身由 markKeyboardClosed 里的 stopEditing 收起；这里只是把焦点交回
+    // 远程输入层，失败也不影响键盘已经收起。
     this.markKeyboardClosed('control-panel');
-    // 将焦点移到 XComponent 以收起键盘
     this.scheduleRemoteInputFocus('keyboard-dismiss');
   }
 
@@ -7177,12 +7413,14 @@ struct RemoteDesktop {
   private resetTouchGesture(): void {
     this.clearTouchRightClickTimer();
     this.clearTouchDirectRightClickTimer();
+    this.cancelDirectTouchPress();
     const wasDragging: boolean = this.touchDragActive;
     if (this.touchDragActive) {
       // 拖拽结束 — 释放左键
       this.sendMouseNow(this.remoteCursorX, this.remoteCursorY, 0, false);
     }
     this.touchFingerCount = 0;
+    this.touchAnchorFingerCount = 0;
     this.touchDragActive = false;
     this.touchDragPending = false;
     this.touchMoved = false;
@@ -7589,14 +7827,18 @@ struct RemoteDesktop {
           if (oldMaxFingers < 2) {
             this.touchDragCursorX = this.remoteCursorX;
             this.touchDragCursorY = this.remoteCursorY;
-            const avg: LocalPoint | null = this.averageTouchPoint(event);
-            if (avg) {
-              this.touchStartLocalX = avg.x;
-              this.touchStartLocalY = avg.y;
-              this.touchLastLocalX = avg.x;
-              this.touchLastLocalY = avg.y;
-            }
           }
+          // 每加一根手指都重新锚定重心：加手指同样会让重心跳变。
+          const avg: LocalPoint | null = this.averageTouchPoint(event);
+          if (avg) {
+            this.touchAnchorFingerCount = this.touchFingerCount;
+            this.touchStartLocalX = avg.x;
+            this.touchStartLocalY = avg.y;
+            this.touchLastLocalX = avg.x;
+            this.touchLastLocalY = avg.y;
+          }
+          // 升级成多指手势：还没发出去的按下直接丢弃，已经按下的才需要释放。
+          this.cancelDirectTouchPress();
           if (this.touchLeftDown) {
             this.sendMouseNow(this.remoteCursorX, this.remoteCursorY, 0, false);
             this.touchLeftDown = false;
@@ -7611,20 +7853,31 @@ struct RemoteDesktop {
         this.touchStartLocalY = point.y;
         this.touchLastLocalX = point.x;
         this.touchLastLocalY = point.y;
-        this.touchLeftDown = true;
         this.lastTouchMs = Date.now();
-        this.sendMouseNow(mapped.x, mapped.y, 0, true);
+        // 先把光标移到目标点并立刻发出去，按下推迟到远端有机会处理 hover 之后。
+        this.queueMouseMove(mapped.x, mapped.y);
+        this.flushMouseMove();
+        this.scheduleDirectTouchPress(mapped.x, mapped.y);
         this.startDirectTouchRightClickTimer();
       } else if (event.type === TouchType.Move) {
         this.touchFingerCount = event.touches.length;
         if (this.touchMaxFingers >= 2) {
           const avg: LocalPoint | null = this.averageTouchPoint(event);
           if (avg) {
-            const dx: number = avg.x - this.touchStartLocalX;
-            const dy: number = avg.y - this.touchStartLocalY;
-            if (Math.sqrt(dx * dx + dy * dy) > TOUCH_CLICK_SLOP_PX) {
-              this.touchMoved = true;
-              this.touchDragPending = false;
+            if (this.touchAnchorFingerCount !== event.touches.length) {
+              // 触点数量变了，重心必然跳变（三指→两指→一指），这不是"手指移动了"。
+              // 重新锚定，否则一次干净的三指轻点会因为手指先后抬起被误判成滑动，
+              // finishThreeFingerPanel 的 !touchMoved 条件就永远不成立。
+              this.touchAnchorFingerCount = event.touches.length;
+              this.touchStartLocalX = avg.x;
+              this.touchStartLocalY = avg.y;
+            } else {
+              const dx: number = avg.x - this.touchStartLocalX;
+              const dy: number = avg.y - this.touchStartLocalY;
+              if (Math.sqrt(dx * dx + dy * dy) > TOUCH_CLICK_SLOP_PX) {
+                this.touchMoved = true;
+                this.touchDragPending = false;
+              }
             }
           }
           return;
@@ -7632,12 +7885,14 @@ struct RemoteDesktop {
         const mapped: MappedPoint = this.mapInputPoint(point.x, point.y);
         this.logMappedInput('touch', point.x, point.y, mapped);
         if (!mapped.inside) { return; }
-        if (this.touchLeftDown) {
+        if (this.touchLeftDown || this.directTouchPressPending) {
           const dx: number = point.x - this.touchStartLocalX;
           const dy: number = point.y - this.touchStartLocalY;
           if (Math.sqrt(dx * dx + dy * dy) > TOUCH_CLICK_SLOP_PX) {
             this.touchMoved = true;
             this.clearTouchDirectRightClickTimer();
+            // 变成拖动了：立刻补发按下，让 DOWN 落在起点而不是跟在移动后面。
+            this.flushDirectTouchPress();
           }
         }
         this.queueMouseMove(mapped.x, mapped.y);
@@ -7673,6 +7928,13 @@ struct RemoteDesktop {
         }
         const mapped: MappedPoint = this.mapInputPoint(point.x, point.y);
         this.logMappedInput('touch', point.x, point.y, mapped);
+        if (event.type === TouchType.Cancel) {
+          // 触摸被系统取消：这一下不算点击，丢弃尚未发出的按下。
+          this.cancelDirectTouchPress();
+        } else {
+          // 快于延迟阈值的轻点在这里补发按下，保证 DOWN 一定早于 UP。
+          this.flushDirectTouchPress();
+        }
         if (this.touchLeftDown) {
           this.sendMouseNow(mapped.x, mapped.y, 0, false);
         }
@@ -7690,6 +7952,11 @@ struct RemoteDesktop {
     if (event.type === TouchType.Down && this.hardwareKeyboardProxyActive) {
       // 触摸获焦同样可能抢走隐藏 TextArea；不重置 IME 会话，稍后恢复代理焦点。
       this.scheduleRemoteInputFocus('touch-down');
+    }
+    if (this.keyboardOpen && (event.type === TouchType.Up || event.type === TouchType.Cancel)) {
+      // 虚拟键盘打开时点画布是"把远端光标放进远端输入框"，不是结束输入。
+      // 画布层的 focusOnTouch 已经关掉，这里再补一次请求作为兜底。
+      this.restoreVirtualKeyboardFocus('canvas-touch');
     }
     const host: RemoteHost | null = this.pendingHost;
     const controlMode: number = host && host.protocol === 'rdp' ? this.rdpControlMode : this.rustdeskControlMode;
@@ -8385,7 +8652,9 @@ struct RemoteDesktop {
       .width('100%').height('100%')
       .backgroundColor('#000000')
       .focusable(true)
-      .focusOnTouch(true)
+      // 虚拟键盘打开时不得因为画布点击而获焦，否则会抢走影子 TextArea 的
+      // 输入法焦点并立刻收起软键盘。
+      .focusOnTouch(!this.keyboardOpen)
       .onHover(this.handleRemoteSurfaceHover)
       .onLoad(this.onXComponentLoad)
       .onDestroy(this.onXComponentDestroy)
@@ -8497,7 +8766,8 @@ struct RemoteDesktop {
         .backgroundColor('rgba(0,0,0,0.01)')
         .hitTestBehavior(HitTestMode.Block)
         .focusable(true)
-        .focusOnTouch(true)
+        // 同 XComponent：虚拟键盘打开期间画布点击只定位远端光标，不抢焦点。
+        .focusOnTouch(!this.keyboardOpen)
         .defaultFocus(true)
         .onFocus((): void => {
           hilog.info(RD_DOMAIN, RD_TAG, 'remote-input-focus target=overlay');
@@ -8591,6 +8861,15 @@ struct RemoteDesktop {
           shiftLocked: this.isModifierLatched('shift'),
           winLocked: this.isModifierLatched('win'),
           fnLayer: this.fnLayer,
+          keyboardOpen: this.keyboardOpen,
+          onToggleKeyboard: (): void => {
+            if (this.keyboardOpen) {
+              this.keepKeyboardAfterSheetClose = false;
+              this.dismissKeyboard();
+            } else {
+              this.openKeyboard();
+            }
+          },
           onTogglePanel: (): void => {
             this.toggleModifierPanel();
             hilog.info(RD_DOMAIN, RD_TAG,
@@ -8618,12 +8897,21 @@ struct RemoteDesktop {
           shiftLatch: this.shiftLatch,
           winLatch: this.winLatch,
           fnLayer: this.fnLayer,
+          keyboardOpen: this.keyboardOpen,
           panelX: this.modifierPanelX,
           panelY: this.modifierPanelY,
           shortcutX: this.shortcutPanelX,
           shortcutY: this.shortcutPanelY,
           onClose: (): void => {
             this.closeModifierPanel();
+          },
+          onToggleKeyboard: (): void => {
+            if (this.keyboardOpen) {
+              this.keepKeyboardAfterSheetClose = false;
+              this.dismissKeyboard();
+            } else {
+              this.openKeyboard();
+            }
           },
           onCloseShortcut: (): void => {
             this.closeShortcutPanel();
@@ -8821,9 +9109,11 @@ struct RemoteDesktop {
         // 输入法未消费的字符事件仍通过现有后置回调兜底；功能键已在 onKeyPreIme 拦截。
         .onKeyEvent(this.handleXComponentKey)
         .onFocus((): void => {
+          this.keyboardProxyFocused = true;
           hilog.info(RD_DOMAIN, RD_TAG, 'remote-input-focus target=keyboard-proxy');
         })
         .onBlur((): void => {
+          this.keyboardProxyFocused = false;
           this.handleRemoteKeyboardFocusLost('keyboard-proxy');
         })
         .onWillInsert((info: InsertValue): boolean => {

--- a/entry/src/main/ets/services/AccountKitService.ets
+++ b/entry/src/main/ets/services/AccountKitService.ets
@@ -40,6 +40,7 @@ interface StoredCredential {
   tokenExpiresAt: number;
   displayName: string;
   loginTime: number;
+  avatarUri?: string;
 }
 
 /** 登录凭据参数 */
@@ -49,6 +50,7 @@ interface CredentialParams {
   authorizationCode: string;
   idToken: string;
   displayName: string;
+  avatarUri?: string;
 }
 
 export class AccountKitService {
@@ -65,16 +67,27 @@ export class AccountKitService {
 
   /** 初始化持久化存储, 从磁盘恢复 */
   async init(context: common.Context): Promise<void> {
+    this.initSync(context);
+  }
+
+  /**
+   * 同步初始化，重复调用安全。
+   *
+   * saveCredential/getXxx 在 dataPreferences 为空时会静默失败，所以每个写入
+   * 或读取凭据的入口都必须先走这里，不能假设别处已经初始化过。
+   */
+  initSync(context: common.Context): void {
+    if (this.dataPreferences !== null) { return; }
     try {
       this.dataPreferences = preferences.getPreferencesSync(context, { name: STORE_NAME });
-      await this.loadFromDisk();
+      this.loadFromDisk();
     } catch (err) {
       hilog.error(0x0015, 'AccountKit', 'AccountKitService 初始化失败: ' + JSON.stringify(err));
     }
   }
 
   /** 从 Preferences 加载凭据 */
-  private async loadFromDisk(): Promise<void> {
+  private loadFromDisk(): void {
     if (!this.dataPreferences) { return; }
     try {
       const raw: string = this.dataPreferences.getSync(KEY_CREDENTIAL, '') as string;
@@ -87,16 +100,24 @@ export class AccountKitService {
     }
   }
 
-  /** 持久化到 Preferences */
-  private async saveToDisk(): Promise<void> {
-    if (!this.dataPreferences) { return; }
+  /**
+   * 持久化到 Preferences。
+   *
+   * 用 flushSync 而不是 flush：这份凭据存在的意义就是熬过系统杀后台，
+   * 异步落盘可能赶不上进程被回收。
+   */
+  private saveToDisk(): void {
+    if (!this.dataPreferences) {
+      hilog.warn(0x0015, 'AccountKit', 'AccountKitService 未初始化, 凭据未落盘');
+      return;
+    }
     try {
       if (this.credential) {
         this.dataPreferences.putSync(KEY_CREDENTIAL, JSON.stringify(this.credential));
       } else {
         this.dataPreferences.deleteSync(KEY_CREDENTIAL);
       }
-      this.dataPreferences.flush();
+      this.dataPreferences.flushSync();
     } catch (err) {
       hilog.error(0x0015, 'AccountKit', 'AccountKitService 保存凭据失败: ' + JSON.stringify(err));
     }
@@ -115,15 +136,16 @@ export class AccountKitService {
       refreshToken: '',
       tokenExpiresAt: 0,
       displayName: cred.displayName || '',
-      loginTime: Date.now()
+      loginTime: Date.now(),
+      avatarUri: cred.avatarUri || ''
     };
-    this.saveToDisk().catch((_: Error) => { /* ignore */ });
+    this.saveToDisk();
   }
 
   /** 清除凭据 (退出登录) */
   clearCredential(): void {
     this.credential = null;
-    this.saveToDisk().catch((_: Error) => { /* ignore */ });
+    this.saveToDisk();
   }
 
   /** 是否有有效凭据 */
@@ -154,6 +176,11 @@ export class AccountKitService {
   /** 获取显示名称 */
   getDisplayName(): string {
     return this.credential?.displayName || '';
+  }
+
+  /** 获取头像地址 (旧版本写入的凭据没有该字段, 返回空串) */
+  getAvatarUri(): string {
+    return this.credential?.avatarUri || '';
   }
 
   /** 登录时间戳 */
@@ -227,7 +254,7 @@ export class AccountKitService {
           this.credential.accessToken = accessToken;
           this.credential.refreshToken = refreshToken;
           this.credential.tokenExpiresAt = Date.now() + (expiresIn || 3600) * 1000;
-          await this.saveToDisk();
+          this.saveToDisk();
         }
 
         hilog.info(DOMAIN, TAG, "[exchangeAuthCode] Access Token 换取成功, expires_in=" + expiresIn.toString());

--- a/entry/src/main/ets/services/RemoteKeyboardAvoidPolicy.ets
+++ b/entry/src/main/ets/services/RemoteKeyboardAvoidPolicy.ets
@@ -1,0 +1,52 @@
+/**
+ * RemoteKeyboardAvoidPolicy.ets — 软键盘弹出时的画布让位计算。
+ *
+ * ArkUI 的页面级键盘避让只会整体上移信箱式画布，它不知道远端输入光标在哪，
+ * 光标落在画面下部时照样被键盘挡住。这里按实际遮挡量算让位。
+ */
+
+/** 判定"被键盘挡住"时，输入光标下方要保留的余量 (vp)。 */
+export const KEYBOARD_CARET_MARGIN_VP: number = 24;
+
+/**
+ * 被挡住时，把光标送到可见区高度的这个比例处。
+ *
+ * 0.5 = 可见区正中，和官方客户端 `_moveToCenterCursor()` 的落点一致。只按最小
+ * 遮挡量上移的话，光标会紧贴键盘顶边，输入框在贴近任务栏时仍然看不全。
+ */
+const CARET_TARGET_RATIO: number = 0.5;
+
+/**
+ * 计算画布还需要额外上移多少像素，才能让远端输入光标舒服地露出来。
+ *
+ * caretLocalYPx / surfaceHeightPx / keyboardHeightPx 都是当前渲染表面的像素。
+ * caretLocalYPx 是在**当前已经上移过**的画面里量到的，所以返回的是增量，
+ * 调用方累加到既有偏移上；线性关系保证一步收敛，不会来回震荡。
+ *
+ * 只上移、不下移：光标本来就在可见区里就完全不动，避免键盘一弹画面就乱跳。
+ */
+export function keyboardCanvasLiftDeltaPx(caretLocalYPx: number, surfaceHeightPx: number,
+  keyboardHeightPx: number, marginPx: number): number {
+  if (!(surfaceHeightPx > 0) || keyboardHeightPx <= 0) {
+    return 0;
+  }
+  const visibleBottomPx: number = surfaceHeightPx - keyboardHeightPx;
+  if (visibleBottomPx <= 0) {
+    return 0;
+  }
+  if (caretLocalYPx + marginPx <= visibleBottomPx) {
+    return 0;
+  }
+  const targetPx: number = visibleBottomPx * CARET_TARGET_RATIO;
+  const deltaPx: number = caretLocalYPx - targetPx;
+  return deltaPx > 0 ? deltaPx : 0;
+}
+
+/** 让位量的上限：把画面最底部的光标送到目标位置所需的量，再多就只是拉出黑边。 */
+export function maxKeyboardCanvasLiftPx(surfaceHeightPx: number, keyboardHeightPx: number): number {
+  const visibleBottomPx: number = surfaceHeightPx - keyboardHeightPx;
+  if (!(surfaceHeightPx > 0) || visibleBottomPx <= 0) {
+    return 0;
+  }
+  return surfaceHeightPx - visibleBottomPx * CARET_TARGET_RATIO;
+}

--- a/entry/src/main/ets/services/RustDeskProConnectionPreflightPolicy.ets
+++ b/entry/src/main/ets/services/RustDeskProConnectionPreflightPolicy.ets
@@ -1,8 +1,111 @@
+import { RustDeskProAccountState } from '../model/RustDeskProModels';
+
 export enum RustDeskProPreflightState {
   IDLE = 0,
   CONNECTING = 1,
   AUTHENTICATED = 2,
   ERROR = 3
+}
+
+/**
+ * Why a rendezvous handshake does or does not carry a Pro session token.
+ *
+ * `requires_login` is the state that matters for diagnostics: an account row
+ * exists for this relay but holds no usable token. That is the normal outcome
+ * after a reinstall, because the access token is local-only by design and
+ * cloud sync restores only the account metadata.
+ */
+export type RustDeskProSessionState = 'not_configured' | 'ready' | 'requires_login';
+
+export interface RustDeskProSessionResolution {
+  token: string;
+  state: RustDeskProSessionState;
+}
+
+/**
+ * Select the Server Pro session token to send with the rendezvous handshake.
+ *
+ * hbbs with account access control enabled refuses an unauthenticated
+ * PunchHoleRequest with "You have not logged in or your login session has
+ * expired", so a logged-in account's token has to reach the FFI layer.
+ *
+ * Resolution order:
+ *   1. Direct connections never touch a rendezvous server — send no token.
+ *   2. The account the host is explicitly bound to (Pro-imported hosts).
+ *   3. Any logged-in account on the same relay, newest login first. This is
+ *      what lets a manually added host on a Pro relay authenticate without
+ *      being re-imported from the address book.
+ *
+ * A tokenless or expired row is never sent as a credential; it is reported as
+ * `requires_login` so the caller can say what to do instead of surfacing the
+ * server's opaque rejection.
+ */
+export function resolveRustDeskProSession(accounts: RustDeskProAccountState[],
+  proAccountId: string, legacyAccountId: string, relayId: string,
+  directEnabled: boolean): RustDeskProSessionResolution {
+  if (directEnabled) { return { token: '', state: 'not_configured' }; }
+
+  const usable = (account: RustDeskProAccountState): boolean =>
+    account.accessToken.length > 0 && account.loginStatus !== 'expired';
+
+  const relay: string = relayId.trim();
+  const boundIds: string[] = [proAccountId.trim(), legacyAccountId.trim()];
+
+  const isBoundRow = (account: RustDeskProAccountState): boolean =>
+    boundIds.indexOf(account.id) >= 0 || (relay.length > 0 && account.relayId === relay);
+
+  for (const boundId of boundIds) {
+    if (boundId.length === 0) { continue; }
+    const bound = accounts.find((account: RustDeskProAccountState): boolean =>
+      account.id === boundId && usable(account));
+    if (bound !== undefined) { return { token: bound.accessToken, state: 'ready' }; }
+  }
+
+  if (relay.length > 0) {
+    let best: RustDeskProAccountState | undefined = undefined;
+    for (const account of accounts) {
+      if (account.relayId !== relay || !usable(account)) { continue; }
+      if (best === undefined || account.lastLoginAt > best.lastLoginAt) { best = account; }
+    }
+    if (best !== undefined) { return { token: best.accessToken, state: 'ready' }; }
+  }
+
+  // No usable token. Distinguish "this relay has an account that needs a fresh
+  // login" from "no Pro account was ever configured" (a plain OSS relay).
+  const stale = accounts.some(isBoundRow);
+  return { token: '', state: stale ? 'requires_login' : 'not_configured' };
+}
+
+/** Substrings hbbs/hbbr use when refusing an unauthenticated connection. */
+const RUSTDESK_LOGIN_REQUIRED_MARKERS: string[] = [
+  'you have not logged in',
+  'login session has expired',
+  'connection is not allowed'
+];
+
+/**
+ * Turn the server's account-control rejection into something actionable.
+ *
+ * Returns '' for every other failure so unrelated errors keep their own
+ * message. This deliberately runs only after a real rejection rather than
+ * blocking the attempt up front: a relay may carry stale account metadata and
+ * still allow anonymous connections when access control is switched off.
+ */
+export function rustDeskProLoginHint(ffiError: string, state: RustDeskProSessionState): string {
+  const lowered: string = ffiError.toLowerCase();
+  const rejected: boolean = RUSTDESK_LOGIN_REQUIRED_MARKERS.some(
+    (marker: string): boolean => lowered.indexOf(marker) >= 0);
+  if (!rejected) { return ''; }
+
+  if (state === 'ready') {
+    return 'Server Pro 登录令牌已被服务器拒绝，请重新登录：设置 → RustDesk 中继 → 登录 Server Pro';
+  }
+  if (state === 'requires_login') {
+    return '该中继的 Server Pro 账号需要重新登录（登录令牌只保存在本机，云同步不会同步它）。' +
+      '请前往：设置 → RustDesk 中继 → 登录 Server Pro';
+  }
+  return '该中继启用了账号访问控制，但本机没有已登录的 Server Pro 账号。' +
+    '请前往：设置 → RustDesk 中继 → 登录 Server Pro';
 }
 
 export function shouldOpenRustDeskProPreflight(protocol: string, sourceType: string,

--- a/entry/src/main/ets/services/RustDeskProCredentialStore.ets
+++ b/entry/src/main/ets/services/RustDeskProCredentialStore.ets
@@ -1,10 +1,13 @@
 import { preferences } from '@kit.ArkData';
 import { cryptoFramework } from '@kit.CryptoArchitectureKit';
 import { common } from '@kit.AbilityKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
 import { RustDeskProAccountState } from '../model/RustDeskProModels';
 
 const STORE_NAME: string = 'RustDeskProCredentials';
 const ACCOUNTS_KEY: string = 'accounts';
+const LOG_DOMAIN: number = 0x0001;
+const LOG_TAG: string = 'RustDeskProStore';
 
 export class RustDeskProCredentialStore {
   private static instance: RustDeskProCredentialStore;
@@ -22,7 +25,18 @@ export class RustDeskProCredentialStore {
 
   init(context: common.Context): void {
     this.context = context;
-    if (!this.loaded) { this.load(); }
+    this.ensureLoaded();
+  }
+
+  /**
+   * 读取/写入前保证磁盘内容已经进过内存。
+   *
+   * load() 读失败不会置位 loaded，所以这里每次都会重试；调用方不需要关心
+   * 是哪个页面先 init 的。
+   */
+  private ensureLoaded(): void {
+    if (this.loaded || !this.context) { return; }
+    this.load();
   }
 
   onDataChange(callback: () => void): () => void {
@@ -42,25 +56,53 @@ export class RustDeskProCredentialStore {
     }
   }
 
+  /**
+   * 从 Preferences 读回账号。
+   *
+   * 失败时**不能**把 loaded 置位：这个 store 是 Server Pro 会话 token 的唯一
+   * 本地副本，一次读取失败如果被当成"读到了 0 个账号"，接下来任何一次 save()
+   * 都会用空数组覆盖磁盘，把 token 永久删掉 —— 表现就是杀后台之后必须重新
+   * 登录一次。读失败保持 loaded=false，让下一次 init() 重试。
+   */
   private load(): void {
-    this.loaded = true;
     if (!this.context) { return; }
+    const loadedAccounts: RustDeskProAccountState[] = [];
     try {
       const prefs = preferences.getPreferencesSync(this.context, { name: STORE_NAME });
       const raw: string = prefs.getSync(ACCOUNTS_KEY, '') as string;
-      if (raw.length === 0) { return; }
-      const parsed: Object = JSON.parse(raw) as Object;
-      if (!Array.isArray(parsed)) { return; }
-      const rows: Object[] = parsed as Object[];
-      for (let i = 0; i < rows.length; i++) {
-        if (rows[i] && typeof rows[i] === 'object') {
-          const row = rows[i] as Record<string, Object>;
-          this.accounts.push(this.fromRecord(row));
+      if (raw.length > 0) {
+        const parsed: Object = JSON.parse(raw) as Object;
+        if (Array.isArray(parsed)) {
+          const rows: Object[] = parsed as Object[];
+          for (let i = 0; i < rows.length; i++) {
+            if (rows[i] && typeof rows[i] === 'object') {
+              const row = rows[i] as Record<string, Object>;
+              loadedAccounts.push(this.fromRecord(row));
+            }
+          }
+        } else {
+          hilog.error(LOG_DOMAIN, LOG_TAG, 'load: 存储内容不是数组，忽略本次读取');
+          return;
         }
       }
-    } catch (_err) {
-      this.accounts = [];
+    } catch (err) {
+      // 保持 loaded=false，绝不让后续 persist() 写空数组覆盖磁盘上的 token。
+      hilog.error(LOG_DOMAIN, LOG_TAG, 'load failed: ' + JSON.stringify(err));
+      return;
     }
+    this.accounts = loadedAccounts;
+    this.loaded = true;
+    hilog.info(LOG_DOMAIN, LOG_TAG, 'load: accounts=' + this.accounts.length.toString() +
+      ' withToken=' + this.tokenBearingCount().toString());
+  }
+
+  /** 诊断用：只统计条数，绝不记录 token 本身。 */
+  private tokenBearingCount(): number {
+    let count: number = 0;
+    for (let i = 0; i < this.accounts.length; i++) {
+      if (this.accounts[i].accessToken.length > 0) { count++; }
+    }
+    return count;
   }
 
   private fromRecord(row: Record<string, Object>): RustDeskProAccountState {
@@ -82,13 +124,21 @@ export class RustDeskProCredentialStore {
   }
 
   private persist(): void {
-    if (!this.context) { return; }
+    if (!this.context) {
+      // 之前这里静默返回：登录成功、内存里有 token、UI 显示"已登录"，但磁盘
+      // 上什么都没有，进程一死 token 就没了。
+      hilog.error(LOG_DOMAIN, LOG_TAG, 'persist skipped: store 未 init(context)，凭据只存在于内存');
+      return;
+    }
     try {
       const prefs = preferences.getPreferencesSync(this.context, { name: STORE_NAME });
       prefs.putSync(ACCOUNTS_KEY, JSON.stringify(this.accounts));
       prefs.flushSync();
-    } catch (_err) {
+      hilog.info(LOG_DOMAIN, LOG_TAG, 'persist: accounts=' + this.accounts.length.toString() +
+        ' withToken=' + this.tokenBearingCount().toString());
+    } catch (err) {
       // The caller still owns the in-memory state; a later init can retry persistence.
+      hilog.error(LOG_DOMAIN, LOG_TAG, 'persist failed: ' + JSON.stringify(err));
     }
   }
 
@@ -122,15 +172,24 @@ export class RustDeskProCredentialStore {
   }
 
   getAll(): RustDeskProAccountState[] {
+    this.ensureLoaded();
     return this.accounts.map((account: RustDeskProAccountState): RustDeskProAccountState => this.clone(account));
   }
 
   get(id: string): RustDeskProAccountState | undefined {
+    this.ensureLoaded();
     const found = this.accounts.find((account: RustDeskProAccountState): boolean => account.id === id);
     return found ? this.clone(found) : undefined;
   }
 
   save(account: RustDeskProAccountState): void {
+    this.ensureLoaded();
+    if (!this.loaded) {
+      // 磁盘读不出来，但用户刚登录成功，这份新 token 不能丢。写入会覆盖掉
+      // 读失败的旧内容，所以要留下痕迹。
+      hilog.warn(LOG_DOMAIN, LOG_TAG,
+        'save: 磁盘内容未成功读入，本次写入会覆盖原有账号 id=' + account.id);
+    }
     const index = this.accounts.findIndex((item: RustDeskProAccountState): boolean => item.id === account.id);
     if (index >= 0) { this.accounts[index] = this.clone(account); }
     else { this.accounts.push(this.clone(account)); }
@@ -139,6 +198,7 @@ export class RustDeskProCredentialStore {
   }
 
   clear(id: string): void {
+    this.ensureLoaded();
     this.accounts = this.accounts.filter((account: RustDeskProAccountState): boolean => account.id !== id);
     this.persist();
     this.emitDataChange();

--- a/entry/src/main/ets/services/RustDeskProSyncPolicy.ets
+++ b/entry/src/main/ets/services/RustDeskProSyncPolicy.ets
@@ -17,6 +17,17 @@ export function shouldPreserveManagedRustDeskRoute(managed: boolean, directEnabl
   return managed && !directEnabled;
 }
 
+/**
+ * 识别历史版本把地址簿 `hash` 摘要按 UTF-8 解码后写进来的坏密码。
+ *
+ * 32 字节随机摘要几乎不可能是合法 UTF-8，解码结果里必定含有替换字符
+ * U+FFFD；真实设备密码不会包含它。这类值对 FFI 永远认证不过，留着只会让
+ * 用户以为"密码记住了"，所以同步时直接清掉，让主机回落到点击批准。
+ */
+export function isCorruptedAddressBookPassword(value: string): boolean {
+  return value.indexOf('�') >= 0;
+}
+
 function peerLabel(peer: RustDeskProPeer): string {
   if (peer.alias.length > 0) { return peer.alias; }
   if (peer.hostname.length > 0) { return peer.hostname; }
@@ -87,7 +98,11 @@ export function reconcileRustDeskProHosts(existing: RemoteHost[], relayId: strin
     host.rustdeskProPlatform = peer.platform;
     host.rustdeskProLastSeenAt = syncedAt;
     host.rustdeskProSyncError = '';
-    if (peer.password.length > 0) { host.password = peer.password; }
+    // 清掉历史版本用地址簿 hash 摘要写进来的坏密码（对 FFI 永远认证不过）。
+    if (isCorruptedAddressBookPassword(host.password)) { host.password = ''; }
+    // 地址簿密码只用来补空位，绝不覆盖用户手动保存的、已经能用的密码 ——
+    // 以前这里是无条件赋值，每次同步都会把正确密码冲掉。
+    if (peer.password.length > 0 && host.password.length === 0) { host.password = peer.password; }
     if (peer.password.length === 0 && host.password.length === 0) {
       // 空密码没有可用的设备凭据；只要用户没有保存密码，就使用官方点击批准闭环。
       host.rustdeskAuthMode = 'request_approval';

--- a/entry/src/main/ets/services/TwoFingerScrollPolicy.ets
+++ b/entry/src/main/ets/services/TwoFingerScrollPolicy.ets
@@ -1,0 +1,69 @@
+/**
+ * TwoFingerScrollPolicy.ets — 触控模式下的双指滚轮判定。
+ *
+ * 触控模式的画布上同时挂着 PinchGesture({ fingers: 2 })，同一组双指手势既
+ * 可能是捏合缩放，也可能是滚动翻页。ArkUI 一旦判成捏合就会通过
+ * canvasPinchInputConsumed 吞掉整条 touch 流，onTouch 再也收不到 Move，
+ * 所以滚动必须在自己的 onTouch 里先一步认出来。
+ *
+ * 认出来之后还要认得住：手指在滑动过程中间距不可能纹丝不动，若每帧重新
+ * 判定，一次抖动就会把手势让回给缩放，表现为滚一半突然开始缩放。因此
+ * nextTwoFingerScrollLatch 只升不降，由调用方在手指全部抬起时复位。
+ */
+
+/** 重心每帧至少移动这么多 vp 才考虑滚动，避免双指静止时的抖动误判。 */
+export const TWO_FINGER_SCROLL_MIN_STEP_VP: number = 0.6;
+
+/**
+ * 纵向位移要达到横向的这个倍数才算滚动。
+ *
+ * 双指横向滑动在很多远端应用里是"左右翻页/后退前进"，留给后续手势，
+ * 这里只认纵向为主的滑动。
+ */
+export const TWO_FINGER_SCROLL_AXIS_RATIO: number = 1.4;
+
+/** 两指间距每帧变化超过这么多 vp 就判定为捏合，不是滚动。 */
+export const TWO_FINGER_SCROLL_MAX_SPREAD_STEP_VP: number = 3.0;
+
+/** 两个触点之间的距离 (vp)。间距的逐帧变化量用来区分捏合与平移。 */
+export function twoFingerSpreadVp(x0: number, y0: number,
+  x1: number, y1: number): number {
+  const dx: number = x1 - x0;
+  const dy: number = y1 - y0;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * 本帧的双指位移是否应该开始按滚轮处理。
+ *
+ * stepDx/stepDy 是两指重心相对上一帧的位移，spreadStepVp 是两指间距相对
+ * 上一帧的变化量，单位都是 vp。
+ */
+export function shouldStartTwoFingerScroll(stepDx: number, stepDy: number,
+  spreadStepVp: number): boolean {
+  if (!Number.isFinite(stepDx) || !Number.isFinite(stepDy) ||
+    !Number.isFinite(spreadStepVp)) {
+    return false;
+  }
+  if (Math.abs(stepDy) < TWO_FINGER_SCROLL_MIN_STEP_VP) {
+    return false;
+  }
+  // 间距在变 = 用户在捏合，这一帧不属于滚动。
+  if (Math.abs(spreadStepVp) > TWO_FINGER_SCROLL_MAX_SPREAD_STEP_VP) {
+    return false;
+  }
+  return Math.abs(stepDy) >= Math.abs(stepDx) * TWO_FINGER_SCROLL_AXIS_RATIO;
+}
+
+/**
+ * 滚动锁存：认过一次就保持到手势结束。
+ *
+ * 调用方负责在所有手指抬起时把 active 复位成 false。
+ */
+export function nextTwoFingerScrollLatch(active: boolean, stepDx: number,
+  stepDy: number, spreadStepVp: number): boolean {
+  if (active) {
+    return true;
+  }
+  return shouldStartTwoFingerScroll(stepDx, stepDy, spreadStepVp);
+}

--- a/entry/src/main/ets/types/rdpnapi.d.ts
+++ b/entry/src/main/ets/types/rdpnapi.d.ts
@@ -360,6 +360,10 @@ export interface SessionConfig {
   rdAccountId?: string;      // API账户ID
   rdServerKey?: string;      // Rendezvous 公钥或共享准入 Key
   rdServerKeyMode?: number;  // 0=legacy/auto, 1=server public key, 2=shared access key
+  // RustDesk Server Pro 账号会话 token → PunchHoleRequest.token / RequestRelay.token。
+  // 开启账号访问控制的 hbbs 用它鉴权；空 = OSS 部署。
+  // Transient only. Never persist this value in RemoteHost or a cloud payload.
+  rdProAccessToken?: string;
 }
 
 export interface SftpFileEntry {

--- a/entry/src/ohosTest/ets/test/RustDeskProConnectionPreflightPolicy.test.ets
+++ b/entry/src/ohosTest/ets/test/RustDeskProConnectionPreflightPolicy.test.ets
@@ -4,9 +4,21 @@ import {
   shouldRouteAfterRustDeskProPreflight,
   shouldKeepRustDeskProSheetOpen,
   rustDeskProPeerIdForConnection,
-  shouldOpenRustDeskProPreflight
+  shouldOpenRustDeskProPreflight,
+  resolveRustDeskProSession,
+  rustDeskProLoginHint
 } from '../../../main/ets/services/RustDeskProConnectionPreflightPolicy';
 import { RemoteHost } from '../../../main/ets/model/RemoteHost';
+import { RustDeskProAccountState } from '../../../main/ets/model/RustDeskProModels';
+
+function proAccount(id: string, relayId: string, accessToken: string,
+  loginStatus: string = 'logged_in', lastLoginAt: number = 0): RustDeskProAccountState {
+  return {
+    id, relayId, serverUrl: 'http://pro.example.com:21114', username: 'u',
+    displayName: 'u', userId: 'uid', accessToken, deviceId: 'dev', deviceUuid: 'uuid',
+    loginStatus, lastLoginAt, lastSyncAt: 0, lastSyncError: ''
+  };
+}
 
 export default function rustDeskProConnectionPreflightPolicyTest(): void {
   describe('RustDeskProConnectionPreflightPolicy', (): void => {
@@ -54,6 +66,90 @@ export default function rustDeskProConnectionPreflightPolicyTest(): void {
       host.rustdeskDirectPort = 21118;
       host.password = '';
       expect(host.getValidationErrors().indexOf('RustDesk 直连模式需要设备密码') >= 0).assertTrue();
+    });
+
+    // hbbs 拒绝未登录的 punch hole，所以 Pro 导入主机必须带上它绑定账号的 token。
+    it('sends_the_token_of_the_account_the_host_is_bound_to', 0, (): void => {
+      const accounts: RustDeskProAccountState[] = [
+        proAccount('rdpro_a', 'relay-1', 'token-a'),
+        proAccount('rdpro_b', 'relay-1', 'token-b')
+      ];
+      const resolved = resolveRustDeskProSession(accounts, 'rdpro_b', '', 'relay-1', false);
+      expect(resolved.token).assertEqual('token-b');
+      expect(resolved.state).assertEqual('ready');
+    });
+
+    // 手动添加在 Pro 中继上的主机没有账号绑定，但仍然需要通过账号鉴权。
+    it('falls_back_to_the_newest_login_on_the_same_relay', 0, (): void => {
+      const accounts: RustDeskProAccountState[] = [
+        proAccount('rdpro_old', 'relay-1', 'token-old', 'logged_in', 1000),
+        proAccount('rdpro_new', 'relay-1', 'token-new', 'logged_in', 2000),
+        proAccount('rdpro_other', 'relay-2', 'token-other', 'logged_in', 9000)
+      ];
+      expect(resolveRustDeskProSession(accounts, '', '', 'relay-1', false).token)
+        .assertEqual('token-new');
+    });
+
+    it('accepts_the_legacy_account_binding_when_the_pro_id_is_missing', 0, (): void => {
+      const accounts: RustDeskProAccountState[] = [proAccount('rdpro_a', 'relay-9', 'token-a')];
+      expect(resolveRustDeskProSession(accounts, '', 'rdpro_a', '', false).token)
+        .assertEqual('token-a');
+    });
+
+    // 重装后云同步只恢复账号元数据，token 是本机数据，会得到一条 requires_login 空令牌行。
+    // 这正是"未登录"报错的成因，必须报告成 requires_login 而不是静默无 token。
+    it('reports_requires_login_for_a_cloud_restored_tokenless_row', 0, (): void => {
+      const restored: RustDeskProAccountState[] = [
+        proAccount('rdpro_a', 'relay-1', '', 'requires_login')
+      ];
+      const resolved = resolveRustDeskProSession(restored, 'rdpro_a', '', 'relay-1', false);
+      expect(resolved.token).assertEqual('');
+      expect(resolved.state).assertEqual('requires_login');
+    });
+
+    // 过期账号送出去只会把"未登录"变成更难懂的凭证被拒错误。
+    it('never_sends_an_expired_token', 0, (): void => {
+      const expired: RustDeskProAccountState[] = [
+        proAccount('rdpro_a', 'relay-1', 'stale-token', 'expired')
+      ];
+      const resolved = resolveRustDeskProSession(expired, 'rdpro_a', '', 'relay-1', false);
+      expect(resolved.token).assertEqual('');
+      expect(resolved.state).assertEqual('requires_login');
+    });
+
+    // 直连不经过 rendezvous，账号 token 在那里没有意义，也不该外发。
+    it('never_sends_a_token_on_direct_connections', 0, (): void => {
+      const accounts: RustDeskProAccountState[] = [proAccount('rdpro_a', 'relay-1', 'token-a')];
+      expect(resolveRustDeskProSession(accounts, 'rdpro_a', '', 'relay-1', true).token)
+        .assertEqual('');
+    });
+
+    // 纯 OSS 中继本来就没有 Pro 账号，不能被当成"需要重新登录"。
+    it('reports_not_configured_when_no_account_is_bound', 0, (): void => {
+      expect(resolveRustDeskProSession([], 'rdpro_a', '', 'relay-1', false).state)
+        .assertEqual('not_configured');
+      const other: RustDeskProAccountState[] = [proAccount('rdpro_a', 'relay-2', 'token-a')];
+      const resolved = resolveRustDeskProSession(other, '', '', 'relay-1', false);
+      expect(resolved.token).assertEqual('');
+      expect(resolved.state).assertEqual('not_configured');
+    });
+
+    // 服务器的账号访问控制报错必须变成可操作的指引。
+    it('maps_the_account_control_rejection_to_an_actionable_hint', 0, (): void => {
+      const serverError = 'connect pipeline failed: state=RequestingRelay, error=The connection ' +
+        'is not allowed. You have not logged in or your login session has expired.';
+      expect(rustDeskProLoginHint(serverError, 'requires_login').length > 0).assertTrue();
+      expect(rustDeskProLoginHint(serverError, 'requires_login').indexOf('登录 Server Pro') >= 0)
+        .assertTrue();
+      expect(rustDeskProLoginHint(serverError, 'not_configured').length > 0).assertTrue();
+      expect(rustDeskProLoginHint(serverError, 'ready').indexOf('已被服务器拒绝') >= 0).assertTrue();
+    });
+
+    // 其他失败必须保留自己的报错，不能被登录指引覆盖。
+    it('leaves_unrelated_failures_untouched', 0, (): void => {
+      expect(rustDeskProLoginHint('punch hole refused: OFFLINE', 'requires_login')).assertEqual('');
+      expect(rustDeskProLoginHint('remote approval timed out', 'ready')).assertEqual('');
+      expect(rustDeskProLoginHint('', 'requires_login')).assertEqual('');
     });
   });
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -58,6 +58,7 @@ import cloudTableAdapterTest from './CloudTableAdapter.test';
 import loginStartupPolicyTest from './LoginStartupPolicy.test';
 import rustDeskProSyncPolicyTest from './RustDeskProSyncPolicy.test';
 import remoteKeyboardAvoidPolicyTest from './RemoteKeyboardAvoidPolicy.test';
+import twoFingerScrollPolicyTest from './TwoFingerScrollPolicy.test';
 
 export default function testsuite() {
   localUnitTest();
@@ -120,4 +121,5 @@ export default function testsuite() {
   loginStartupPolicyTest();
   rustDeskProSyncPolicyTest();
   remoteKeyboardAvoidPolicyTest();
+  twoFingerScrollPolicyTest();
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -56,6 +56,8 @@ import sensitiveDataStatePolicyTest from './SensitiveDataStatePolicy.test';
 import sensitiveDataMigrationPolicyTest from './SensitiveDataMigrationPolicy.test';
 import cloudTableAdapterTest from './CloudTableAdapter.test';
 import loginStartupPolicyTest from './LoginStartupPolicy.test';
+import rustDeskProSyncPolicyTest from './RustDeskProSyncPolicy.test';
+import remoteKeyboardAvoidPolicyTest from './RemoteKeyboardAvoidPolicy.test';
 
 export default function testsuite() {
   localUnitTest();
@@ -116,4 +118,6 @@ export default function testsuite() {
   sensitiveDataMigrationPolicyTest();
   cloudTableAdapterTest();
   loginStartupPolicyTest();
+  rustDeskProSyncPolicyTest();
+  remoteKeyboardAvoidPolicyTest();
 }

--- a/entry/src/test/RemoteKeyboardAvoidPolicy.test.ets
+++ b/entry/src/test/RemoteKeyboardAvoidPolicy.test.ets
@@ -1,0 +1,49 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  keyboardCanvasLiftDeltaPx,
+  maxKeyboardCanvasLiftPx
+} from '../main/ets/services/RemoteKeyboardAvoidPolicy';
+
+export default function remoteKeyboardAvoidPolicyTest() {
+  describe('RemoteKeyboardAvoidPolicy', () => {
+    it('lifts_only_when_the_caret_is_behind_the_keyboard', 0, () => {
+      // 光标在可见区内，不需要让位。
+      expect(keyboardCanvasLiftDeltaPx(200, 1000, 400, 20)).assertEqual(0);
+      // 正好卡在余量边界上，不再动。
+      expect(keyboardCanvasLiftDeltaPx(580, 1000, 400, 20)).assertEqual(0);
+      // 被挡住时送到可见区中部 (600/2=300)：700 - 300 = 400。
+      expect(keyboardCanvasLiftDeltaPx(700, 1000, 400, 20)).assertEqual(400);
+    });
+
+    it('lifts_enough_for_a_caret_sitting_on_the_taskbar', 0, () => {
+      // 输入框贴着任务栏：光标几乎在画面最底部，最小上移只能让它紧贴键盘顶边，
+      // 看不全输入区；送到可见区中部才够用。
+      const lift: number = keyboardCanvasLiftDeltaPx(990, 1000, 400, 20);
+      expect(lift).assertEqual(690);
+      // 上移后光标落在 300，正好是可见区 600 的中部。
+      expect(990 - lift).assertEqual(300);
+    });
+
+    it('never_lifts_without_a_keyboard_or_a_surface', 0, () => {
+      expect(keyboardCanvasLiftDeltaPx(700, 1000, 0, 20)).assertEqual(0);
+      expect(keyboardCanvasLiftDeltaPx(700, 0, 400, 20)).assertEqual(0);
+      // 键盘比画面还高时不做无意义的位移。
+      expect(keyboardCanvasLiftDeltaPx(700, 400, 400, 20)).assertEqual(0);
+    });
+
+    it('converges_in_one_step_because_the_delta_is_measured_on_the_shifted_frame', 0, () => {
+      // 第一次量到 caret 在 700，上移之后再量应该已经在可见区里 → 增量归零，
+      // 不会来回震荡。
+      const first: number = keyboardCanvasLiftDeltaPx(700, 1000, 400, 20);
+      expect(keyboardCanvasLiftDeltaPx(700 - first, 1000, 400, 20)).assertEqual(0);
+    });
+
+    it('caps_the_lift_at_what_a_bottom_edge_caret_needs', 0, () => {
+      // 可见区 600，目标落点 300 → 最底部的光标最多需要 1000-300=700。
+      expect(maxKeyboardCanvasLiftPx(1000, 400)).assertEqual(700);
+      expect(maxKeyboardCanvasLiftPx(1000, 0)).assertEqual(1000);
+      expect(maxKeyboardCanvasLiftPx(400, 400)).assertEqual(0);
+      expect(maxKeyboardCanvasLiftPx(0, 400)).assertEqual(0);
+    });
+  });
+}

--- a/entry/src/test/RustDeskProSyncPolicy.test.ets
+++ b/entry/src/test/RustDeskProSyncPolicy.test.ets
@@ -2,6 +2,7 @@ import { describe, it, expect } from '@ohos/hypium';
 import { RemoteHost } from '../main/ets/model/RemoteHost';
 import { RustDeskProPeer } from '../main/ets/model/RustDeskProModels';
 import {
+  isCorruptedAddressBookPassword,
   reconcileRustDeskProHosts,
   rustDeskProHostId,
   shouldPreserveManagedRustDeskRoute
@@ -70,6 +71,44 @@ export default function rustDeskProSyncPolicyTest() {
       expect(second.hosts.length).assertEqual(1);
       expect(second.missingIds.length).assertEqual(1);
       expect(second.hosts[0].rustdeskProSyncError).assertEqual('not_seen');
+    });
+
+    it('never_overwrites_a_saved_password_on_resync', 0, () => {
+      const first = reconcileRustDeskProHosts([], 'relay-1', 'acct-1', [peer('123', 'Office')], 100);
+      // 用户自己填的、能用的设备密码。
+      first.hosts[0].password = 'my-real-password';
+      first.hosts[0].rustdeskAuthMode = 'password';
+      const fromServer = peer('123', 'Office');
+      fromServer.password = 'address-book-value';
+      const second = reconcileRustDeskProHosts(first.hosts, 'relay-1', 'acct-1', [fromServer], 200);
+      expect(second.hosts[0].password).assertEqual('my-real-password');
+      expect(second.hosts[0].rustdeskAuthMode).assertEqual('password');
+    });
+
+    it('fills_an_empty_password_from_the_address_book', 0, () => {
+      const fromServer = peer('123', 'Office');
+      fromServer.password = 'address-book-value';
+      const result = reconcileRustDeskProHosts([], 'relay-1', 'acct-1', [fromServer], 100);
+      expect(result.hosts[0].password).assertEqual('address-book-value');
+      expect(result.hosts[0].rustdeskAuthMode).assertEqual('password');
+    });
+
+    it('clears_the_hash_derived_garbage_password_written_by_older_builds', 0, () => {
+      const first = reconcileRustDeskProHosts([], 'relay-1', 'acct-1', [peer('123', 'Office')], 100);
+      // 旧版本把地址簿 hash 摘要按 UTF-8 解码后存下来的结果。
+      first.hosts[0].password = '��7��';
+      first.hosts[0].rustdeskAuthMode = 'password';
+      const second = reconcileRustDeskProHosts(first.hosts, 'relay-1', 'acct-1', [peer('123', 'Office')], 200);
+      expect(second.hosts[0].password).assertEqual('');
+      // 没有可用凭据时回落到官方的点击批准闭环。
+      expect(second.hosts[0].rustdeskAuthMode).assertEqual('request_approval');
+    });
+
+    it('recognizes_only_replacement_char_passwords_as_corrupted', 0, () => {
+      expect(isCorruptedAddressBookPassword('��')).assertTrue();
+      expect(isCorruptedAddressBookPassword('P@ssw0rd!')).assertFalse();
+      expect(isCorruptedAddressBookPassword('')).assertFalse();
+      expect(isCorruptedAddressBookPassword('密码123')).assertFalse();
     });
 
     it('allows_a_managed_direct_host_to_edit_its_local_lan_endpoint', 0, () => {

--- a/entry/src/test/TwoFingerScrollPolicy.test.ets
+++ b/entry/src/test/TwoFingerScrollPolicy.test.ets
@@ -1,0 +1,61 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  nextTwoFingerScrollLatch,
+  shouldStartTwoFingerScroll,
+  twoFingerSpreadVp,
+  TWO_FINGER_SCROLL_MAX_SPREAD_STEP_VP,
+  TWO_FINGER_SCROLL_MIN_STEP_VP
+} from '../main/ets/services/TwoFingerScrollPolicy';
+
+export default function twoFingerScrollPolicyTest(): void {
+  describe('TwoFingerScrollPolicy_spread', (): void => {
+    it('should_measure_distance_between_two_contacts', 0, (): void => {
+      expect(twoFingerSpreadVp(0, 0, 3, 4)).assertEqual(5);
+      expect(twoFingerSpreadVp(10, 10, 10, 10)).assertEqual(0);
+    });
+  });
+
+  describe('TwoFingerScrollPolicy_decision', (): void => {
+    it('should_scroll_on_vertical_drag_with_stable_spread', 0, (): void => {
+      expect(shouldStartTwoFingerScroll(0, 6, 0)).assertTrue();
+      expect(shouldStartTwoFingerScroll(0, -6, 0.5)).assertTrue();
+    });
+
+    it('should_ignore_jitter_below_min_step', 0, (): void => {
+      const belowMin: number = TWO_FINGER_SCROLL_MIN_STEP_VP - 0.1;
+      expect(shouldStartTwoFingerScroll(0, belowMin, 0)).assertFalse();
+      expect(shouldStartTwoFingerScroll(0, 0, 0)).assertFalse();
+    });
+
+    it('should_yield_to_pinch_when_spread_changes', 0, (): void => {
+      const spreading: number = TWO_FINGER_SCROLL_MAX_SPREAD_STEP_VP + 0.5;
+      expect(shouldStartTwoFingerScroll(0, 6, spreading)).assertFalse();
+      expect(shouldStartTwoFingerScroll(0, 6, -spreading)).assertFalse();
+    });
+
+    it('should_reject_horizontally_dominant_drag', 0, (): void => {
+      expect(shouldStartTwoFingerScroll(20, 2, 0)).assertFalse();
+      // 45 度斜滑：纵向没有达到横向的 1.4 倍，不算滚动。
+      expect(shouldStartTwoFingerScroll(6, 6, 0)).assertFalse();
+    });
+
+    it('should_reject_non_finite_input', 0, (): void => {
+      expect(shouldStartTwoFingerScroll(Number.NaN, 6, 0)).assertFalse();
+      expect(shouldStartTwoFingerScroll(0, Number.NaN, 0)).assertFalse();
+      expect(shouldStartTwoFingerScroll(0, 6, Number.NaN)).assertFalse();
+    });
+  });
+
+  describe('TwoFingerScrollPolicy_latch', (): void => {
+    it('should_keep_scrolling_once_recognized', 0, (): void => {
+      // 一旦锁存，后续帧即使间距抖动或转为横向也继续按滚轮处理。
+      const spreading: number = TWO_FINGER_SCROLL_MAX_SPREAD_STEP_VP + 5;
+      expect(nextTwoFingerScrollLatch(true, 20, 0.1, spreading)).assertTrue();
+    });
+
+    it('should_stay_idle_until_a_real_scroll_step', 0, (): void => {
+      expect(nextTwoFingerScrollLatch(false, 0, 0.1, 0)).assertFalse();
+      expect(nextTwoFingerScrollLatch(false, 0, 6, 0)).assertTrue();
+    });
+  });
+}

--- a/hvigor/hvigor-config.json5
+++ b/hvigor/hvigor-config.json5
@@ -1,5 +1,5 @@
 {
-  "modelVersion": "6.0.0",
+  "modelVersion": "6.1.0",
   "dependencies": {
   },
   "execution": {

--- a/oh-package.json5
+++ b/oh-package.json5
@@ -1,5 +1,5 @@
 {
-  "modelVersion": "6.0.0",
+  "modelVersion": "6.1.0",
   "description": "Please describe the basic information.",
   "dependencies": {
   },

--- a/rustdesk_ffi/.cargo/config.toml
+++ b/rustdesk_ffi/.cargo/config.toml
@@ -1,15 +1,16 @@
-# OHOS 交叉编译基础配置。
-# scripts/build_rustdesk_ffi_ohos.sh 注入当前平台的 linker 和 sysroot；
-# macOS 的 scripts/macos_env.sh 也提供同样的目标环境变量。
+# OHOS 交叉编译配置。
+# RustDesk FFI 编译时 CC_*/CXX_*/AR_* 和 OPUS_LIB_DIR 由环境变量注入。
 
 [target.aarch64-unknown-linux-ohos]
-linker = "clang++"
+linker = "C:/ohos_sdk/default/openharmony/native/llvm/bin/clang++.exe"
 rustflags = [
     "-C", "link-arg=--target=aarch64-linux-ohos",
+    "-C", "link-arg=--sysroot=C:/ohos_sdk/default/openharmony/native/sysroot",
 ]
 
 [target.x86_64-unknown-linux-ohos]
-linker = "clang++"
+linker = "C:/ohos_sdk/default/openharmony/native/llvm/bin/clang++.exe"
 rustflags = [
     "-C", "link-arg=--target=x86_64-linux-ohos",
+    "-C", "link-arg=--sysroot=C:/ohos_sdk/default/openharmony/native/sysroot",
 ]

--- a/rustdesk_ffi/src/connector.rs
+++ b/rustdesk_ffi/src/connector.rs
@@ -183,6 +183,19 @@ impl<'a> RendezvousCredentials<'a> {
             server_public_key: if shared_access_key { None } else { Some(access_key) },
         }
     }
+
+    /// Upstream only negotiates a secure rendezvous channel when it has both a
+    /// key and a token — the encryption exists to protect the token, which is
+    /// an account credential and must never cross the wire in clear text.
+    ///
+    /// A shared `-k` access value cannot verify the server's signed ephemeral
+    /// key, so the handshake is impossible in that mode; the caller keeps the
+    /// plain channel instead of pretending the peer was authenticated.
+    fn should_secure_rendezvous(&self, token: &str) -> bool {
+        !token.is_empty()
+            && !self.access_key.trim().is_empty()
+            && self.server_public_key.is_some()
+    }
 }
 
 /// 完整连接上下文
@@ -252,18 +265,33 @@ impl RustDeskConnector {
         fps: u32,
         request_approval: bool,
         shared_access_key: bool,
+        token: &str,
     ) -> io::Result<()> {
         let credentials = RendezvousCredentials::new(server_key, shared_access_key);
+        let secure_rendezvous = credentials.should_secure_rendezvous(token);
         // === Phase 1: Rendezvous 握手 ===
         self.state = ConnState::RendezvousConnecting;
         let mut rd = RendezvousClient::new();
         // 客户端连接远端 ID 时不要 RegisterPeer；RegisterPeer 是被控端注册自己的 ID。
-        // 普通密码连接没有 token，按 upstream 行为跳过 ID server secure_tcp，仅跳过服务端
-        // 主动发来的 KeyExchange 后读取 PunchHoleResponse。
-        rd.connect(rendezvous_host, rendezvous_port, server_key, false)?;
+        // 没有 token 时按 upstream 行为跳过 ID server secure_tcp，仅跳过服务端主动
+        // 发来的 KeyExchange 后读取 PunchHoleResponse；带 Server Pro 会话 token 时
+        // 必须先完成 secure_tcp，否则 token 会以明文发送。
+        eprintln!(
+            "[RustDesk-FFI] rendezvous connect host={} port={} secure={} token={}",
+            rendezvous_host,
+            rendezvous_port,
+            secure_rendezvous,
+            if token.is_empty() { "absent" } else { "present" }
+        );
+        rd.connect(
+            rendezvous_host,
+            rendezvous_port,
+            server_key,
+            secure_rendezvous,
+        )?;
 
         self.state = ConnState::RequestingRelay;
-        let punch = rd.request_punch_hole(peer_id, credentials.access_key)?;
+        let punch = rd.request_punch_hole(peer_id, credentials.access_key, token)?;
 
         // === Phase 2: Peer TCP + 加密通道 ===
         eprintln!(
@@ -280,22 +308,41 @@ impl RustDeskConnector {
                 "[RustDesk-FFI] using relay uuid from rendezvous uuid={} relay_server={}",
                 relay_uuid, punch.relay_server
             );
-            rd.create_relay(peer_id, &relay_uuid, &punch.relay_server, credentials.access_key)?
+            rd.create_relay(
+                peer_id,
+                &relay_uuid,
+                &punch.relay_server,
+                credentials.access_key,
+                token,
+            )?
         } else if !punch.relay_server.trim().is_empty() {
             self.state = ConnState::RequestingRelay;
             let mut relay_rd = RendezvousClient::new();
-            relay_rd.connect(rendezvous_host, rendezvous_port, server_key, false)?;
+            relay_rd.connect(
+                rendezvous_host,
+                rendezvous_port,
+                server_key,
+                secure_rendezvous,
+            )?;
             let relay_uuid = relay_rd.request_relay_uuid(
                 peer_id,
                 &punch.relay_server,
                 !punch.signed_pk.is_empty(),
+                credentials.access_key,
+                token,
             )?;
             self.state = ConnState::ConnectingToPeer;
             eprintln!(
                 "[RustDesk-FFI] relay approved uuid={} relay_server={}",
                 relay_uuid, punch.relay_server
             );
-            relay_rd.create_relay(peer_id, &relay_uuid, &punch.relay_server, credentials.access_key)?
+            relay_rd.create_relay(
+                peer_id,
+                &relay_uuid,
+                &punch.relay_server,
+                credentials.access_key,
+                token,
+            )?
         } else if let Some(peer_addr) = punch.peer_addr {
             self.state = ConnState::ConnectingToPeer;
             self.peer_addr = Some(peer_addr);
@@ -429,22 +476,29 @@ impl RustDeskConnector {
         remote_dir: &str,
         request_approval: bool,
         shared_access_key: bool,
+        token: &str,
     ) -> io::Result<()> {
         let credentials = RendezvousCredentials::new(server_key, shared_access_key);
+        let secure_rendezvous = credentials.should_secure_rendezvous(token);
         crate::set_last_error(format!(
             "file-transfer connecting rendezvous host={} port={} peer={} dir={}",
             rendezvous_host, rendezvous_port, peer_id, remote_dir
         ));
         self.state = ConnState::RendezvousConnecting;
         let mut rd = RendezvousClient::new();
-        rd.connect(rendezvous_host, rendezvous_port, server_key, false)?;
+        rd.connect(
+            rendezvous_host,
+            rendezvous_port,
+            server_key,
+            secure_rendezvous,
+        )?;
 
         crate::set_last_error(format!(
             "file-transfer requesting punch peer={} dir={}",
             peer_id, remote_dir
         ));
         self.state = ConnState::RequestingRelay;
-        let punch = rd.request_punch_hole(peer_id, credentials.access_key)?;
+        let punch = rd.request_punch_hole(peer_id, credentials.access_key, token)?;
         crate::set_last_error(format!(
             "file-transfer punch peer_addr={:?} relay_server={} relay_uuid={:?} signed_pk_len={}",
             punch.peer_addr,
@@ -466,7 +520,13 @@ impl RustDeskConnector {
                 punch.relay_server, relay_uuid
             ));
             self.state = ConnState::ConnectingToPeer;
-            rd.create_relay(peer_id, &relay_uuid, &punch.relay_server, credentials.access_key)?
+            rd.create_relay(
+                peer_id,
+                &relay_uuid,
+                &punch.relay_server,
+                credentials.access_key,
+                token,
+            )?
         } else if !punch.relay_server.trim().is_empty() {
             self.state = ConnState::RequestingRelay;
             let mut relay_rd = RendezvousClient::new();
@@ -474,18 +534,31 @@ impl RustDeskConnector {
                 "file-transfer requesting relay uuid server={}",
                 punch.relay_server
             ));
-            relay_rd.connect(rendezvous_host, rendezvous_port, server_key, false)?;
+            relay_rd.connect(
+                rendezvous_host,
+                rendezvous_port,
+                server_key,
+                secure_rendezvous,
+            )?;
             let relay_uuid = relay_rd.request_relay_uuid(
                 peer_id,
                 &punch.relay_server,
                 !punch.signed_pk.is_empty(),
+                credentials.access_key,
+                token,
             )?;
             crate::set_last_error(format!(
                 "file-transfer connecting relay server={} uuid={}",
                 punch.relay_server, relay_uuid
             ));
             self.state = ConnState::ConnectingToPeer;
-            relay_rd.create_relay(peer_id, &relay_uuid, &punch.relay_server, credentials.access_key)?
+            relay_rd.create_relay(
+                peer_id,
+                &relay_uuid,
+                &punch.relay_server,
+                credentials.access_key,
+                token,
+            )?
         } else if let Some(peer_addr) = punch.peer_addr {
             crate::set_last_error(format!("file-transfer connecting peer addr={}", peer_addr));
             self.state = ConnState::ConnectingToPeer;
@@ -2795,6 +2868,27 @@ mod tests {
         value.set_width(width);
         value.set_height(height);
         value
+    }
+
+    /// The rendezvous channel is encrypted only to protect an account token.
+    /// Without a token there is nothing to hide, and a shared `-k` value cannot
+    /// verify the server signature the handshake depends on.
+    #[test]
+    fn rendezvous_is_secured_only_when_a_token_needs_protecting() {
+        let public_key = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGH=";
+
+        // Public-key mode with a token: encrypt before sending the token.
+        assert!(RendezvousCredentials::new(public_key, false).should_secure_rendezvous("tok"));
+
+        // No token: upstream keeps the plain channel.
+        assert!(!RendezvousCredentials::new(public_key, false).should_secure_rendezvous(""));
+
+        // Shared access key cannot verify the server's signed ephemeral key.
+        assert!(!RendezvousCredentials::new("tenant-key", true).should_secure_rendezvous("tok"));
+
+        // An empty/whitespace key gives the handshake nothing to verify against.
+        assert!(!RendezvousCredentials::new("", false).should_secure_rendezvous("tok"));
+        assert!(!RendezvousCredentials::new("   ", false).should_secure_rendezvous("tok"));
     }
 
     #[test]

--- a/rustdesk_ffi/src/lib.rs
+++ b/rustdesk_ffi/src/lib.rs
@@ -152,6 +152,10 @@ pub struct RustDeskConfig {
     /// 0=legacy/auto, 1=Ed25519 server public key, 2=shared hbbs/hbbr -k text.
     /// Appended to preserve the established C ABI field order.
     pub key_mode: c_int,
+    /// RustDesk Server Pro 账号会话 token (`PunchHoleRequest.token` /
+    /// `RequestRelay.token`). 空 = OSS 部署，不做账号鉴权。
+    /// Appended to preserve the established C ABI field order.
+    pub token: *const c_char,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -452,6 +456,7 @@ struct RustDeskClient {
     shared_access_key: bool,
     password: String,
     request_approval: bool,
+    token: String,
     controls: Arc<ControlInbox>,
     shutdown_stream: Option<TcpStream>,
     stream_handle: Option<std::thread::JoinHandle<io::Result<()>>>,
@@ -874,6 +879,13 @@ pub extern "C" fn rustdesk_connect(
     let server_key = ffi_string(config.key);
     let shared_access_key = config.key_mode == 2;
     let password = ffi_string(config.password);
+    // Direct peer sessions never reach a rendezvous server, so an account
+    // token has no meaning there and must not be retained.
+    let token = if config.direct_connection {
+        String::new()
+    } else {
+        ffi_string(config.token)
+    };
     let request_approval = config.auth_mode == 1 && !config.direct_connection;
     let privacy_mode = config.privacy_mode;
     let audio_enabled = config.audio_enabled;
@@ -885,7 +897,7 @@ pub extern "C" fn rustdesk_connect(
     let req_width = stream_params.req_width;
     let req_height = stream_params.req_height;
     eprintln!(
-        "[RustDesk-FFI] config profile={:?} codec={} raw_quality={} quality={} raw_fps={} fps={} audio={} res={}x{}",
+        "[RustDesk-FFI] config profile={:?} codec={} raw_quality={} quality={} raw_fps={} fps={} audio={} res={}x{} pro_token={}",
         config.profile,
         preferred_codec,
         config.image_quality,
@@ -894,7 +906,9 @@ pub extern "C" fn rustdesk_connect(
         effective_fps,
         if audio_enabled { "on" } else { "off" },
         req_width,
-        req_height
+        req_height,
+        // Never log the token itself — only whether one was supplied.
+        if token.is_empty() { "absent" } else { "present" }
     );
 
     if host.is_empty() {
@@ -957,6 +971,7 @@ pub extern "C" fn rustdesk_connect(
             effective_fps,
             request_approval,
             shared_access_key,
+            &token,
         )
     };
 
@@ -1087,6 +1102,7 @@ pub extern "C" fn rustdesk_connect(
                 shared_access_key,
                 password,
                 request_approval,
+                token,
                 controls,
                 shutdown_stream,
                 stream_handle: Some(stream_handle),
@@ -1390,6 +1406,7 @@ pub extern "C" fn rustdesk_send_file(
     let peer_id = ctx.peer_id.clone();
     let password = ctx.password.clone();
     let request_approval = ctx.request_approval;
+    let token = ctx.token.clone();
     let remote_path_owned = path.clone();
     let remote_dir = split_remote_file_path(&path).0.to_string();
     let transfer_status = Arc::clone(&ctx.transfer_status);
@@ -1399,7 +1416,7 @@ pub extern "C" fn rustdesk_send_file(
             let mut connector = connector::RustDeskConnector::new();
             connector
                 .connect_file_transfer(&host, port, &server_key, &peer_id, &password, &remote_dir,
-                    request_approval, shared_access_key)
+                    request_approval, shared_access_key, &token)
                 .and_then(|_| {
                     connector.upload_file_once(
                         &remote_path_owned,
@@ -1492,6 +1509,7 @@ mod tests {
             shared_access_key: false,
             password: String::new(),
             request_approval: false,
+            token: String::new(),
             controls: Arc::new(ControlInbox::default()),
             shutdown_stream: None,
             stream_handle: None,
@@ -1589,6 +1607,7 @@ mod tests {
         let key = CString::new("").unwrap();
         let username = CString::new("test").unwrap();
         let password = CString::new("").unwrap();
+        let token = CString::new("").unwrap();
 
         let cfg = RustDeskConfig {
             host: host.as_ptr(),
@@ -1607,6 +1626,7 @@ mod tests {
             direct_connection: false,
             auth_mode: 0,
             key_mode: 1,
+            token: token.as_ptr(),
         };
 
         extern "C" fn dummy_frame(_frame: *const FfiVideoFrame, _data: *mut c_void) {}
@@ -1636,6 +1656,7 @@ mod tests {
         let key = CString::new("1:encrypted-value").unwrap();
         let username = CString::new("test").unwrap();
         let password = CString::new("").unwrap();
+        let token = CString::new("").unwrap();
         let cfg = RustDeskConfig {
             host: host.as_ptr(),
             port: 21116,
@@ -1653,6 +1674,7 @@ mod tests {
             direct_connection: false,
             auth_mode: 0,
             key_mode: 1,
+            token: token.as_ptr(),
         };
 
         extern "C" fn dummy_frame(_frame: *const FfiVideoFrame, _data: *mut c_void) {}
@@ -1728,6 +1750,7 @@ mod tests {
             direct_connection: false,
             auth_mode: 0,
             key_mode: 1,
+            token: std::ptr::null(),
         };
 
         let params = resolve_stream_params_for_config(&cfg);
@@ -1758,6 +1781,7 @@ mod tests {
             direct_connection: false,
             auth_mode: 0,
             key_mode: 1,
+            token: std::ptr::null(),
         };
 
         assert_eq!(resolve_stream_params_for_config(&cfg).effective_fps, 60);

--- a/rustdesk_ffi/src/protocol/rendezvous.rs
+++ b/rustdesk_ffi/src/protocol/rendezvous.rs
@@ -53,7 +53,7 @@ fn validated_server_key(server_key: &str) -> io::Result<&str> {
     })
 }
 
-fn punch_hole_request_message(peer_id: &str, licence_key: &str) -> RendezvousMessage {
+fn punch_hole_request_message(peer_id: &str, licence_key: &str, token: &str) -> RendezvousMessage {
     let mut req = PunchHoleRequest::new();
     req.set_id(peer_id.to_string());
     req.set_nat_type(NatType::SYMMETRIC);
@@ -61,18 +61,30 @@ fn punch_hole_request_message(peer_id: &str, licence_key: &str) -> RendezvousMes
     req.set_conn_type(ConnType::DEFAULT_CONN);
     req.set_version("harmonyos-rustdesk-ffi".to_string());
     req.set_force_relay(true);
+    // Server Pro enforces account access control on this field.  An empty
+    // token keeps the OSS behaviour; a Pro session token is what turns
+    // "you have not logged in" into an approved punch hole.
+    req.set_token(token.to_string());
 
     let mut msg = RendezvousMessage::new();
     msg.union = Some(RendezvousMessage_oneof_union::punch_hole_request(req));
     msg
 }
 
-fn request_relay_message(id: &str, uuid: &str, licence_key: &str) -> RendezvousMessage {
+fn request_relay_message(
+    id: &str,
+    uuid: &str,
+    licence_key: &str,
+    token: &str,
+) -> RendezvousMessage {
     let mut req = RequestRelay::new();
     req.set_id(id.to_string());
     req.set_uuid(uuid.to_string());
     req.set_licence_key(licence_key.to_string());
     req.set_conn_type(ConnType::DEFAULT_CONN);
+    // hbbr applies the same account check as hbbs, so the relay handshake
+    // must carry the session token too.
+    req.set_token(token.to_string());
 
     let mut msg = RendezvousMessage::new();
     msg.union = Some(RendezvousMessage_oneof_union::request_relay(req));
@@ -116,18 +128,21 @@ impl RendezvousClient {
         &mut self,
         peer_id: &str,
         server_key: &str,
+        token: &str,
     ) -> io::Result<PunchHoleInfo> {
         self.ensure_connected()?;
         let req_debug = format!(
-            "peer_id={}, nat=SYMMETRIC, conn=DEFAULT_CONN, force_relay=true, version=harmonyos-rustdesk-ffi",
-            peer_id
+            "peer_id={}, nat=SYMMETRIC, conn=DEFAULT_CONN, force_relay=true, version=harmonyos-rustdesk-ffi, token={}, secure={}",
+            peer_id,
+            if token.is_empty() { "absent" } else { "present" },
+            self.secure_key.is_some()
         );
 
         // hbbs `-k` compares this protobuf string verbatim.  It may be a
         // normal signing public key or an arbitrary administrator supplied
         // shared access value; verification is handled separately by the
         // connector when a public key is actually available.
-        let msg = punch_hole_request_message(peer_id, server_key);
+        let msg = punch_hole_request_message(peer_id, server_key, token);
         self.send_message(&msg)?;
 
         let response = self.read_next_non_keyexchange()?;
@@ -243,6 +258,8 @@ impl RendezvousClient {
         id: &str,
         uuid: &str,
         relay_server: &str,
+        server_key: &str,
+        token: &str,
     ) -> io::Result<SocketAddr> {
         self.ensure_connected()?;
 
@@ -251,6 +268,8 @@ impl RendezvousClient {
         req.set_uuid(uuid.to_string());
         req.set_relay_server(relay_server.to_string());
         req.set_secure(true);
+        req.set_licence_key(server_key.to_string());
+        req.set_token(token.to_string());
 
         let mut msg = RendezvousMessage::new();
         msg.union = Some(RendezvousMessage_oneof_union::request_relay(req));
@@ -297,13 +316,19 @@ impl RendezvousClient {
         id: &str,
         relay_server: &str,
         secure: bool,
+        server_key: &str,
+        token: &str,
     ) -> io::Result<String> {
         self.ensure_connected()?;
 
         let uuid = new_relay_uuid();
         eprintln!(
-            "[RustDesk-FFI] request relay id={} uuid={} relay_server={} secure={}",
-            id, uuid, relay_server, secure
+            "[RustDesk-FFI] request relay id={} uuid={} relay_server={} secure={} token={}",
+            id,
+            uuid,
+            relay_server,
+            secure,
+            if token.is_empty() { "absent" } else { "present" }
         );
 
         let mut req = RequestRelay::new();
@@ -311,6 +336,11 @@ impl RendezvousClient {
         req.set_uuid(uuid.clone());
         req.set_relay_server(relay_server.to_string());
         req.set_secure(secure);
+        // hbbs applies the same `-k` and account checks to RequestRelay as it
+        // does to PunchHoleRequest; omitting either credential makes this the
+        // next step to be refused once the punch hole is approved.
+        req.set_licence_key(server_key.to_string());
+        req.set_token(token.to_string());
 
         let mut msg = RendezvousMessage::new();
         msg.union = Some(RendezvousMessage_oneof_union::request_relay(req));
@@ -354,6 +384,7 @@ impl RendezvousClient {
         uuid: &str,
         relay_server: &str,
         server_key: &str,
+        token: &str,
     ) -> io::Result<TcpStream> {
         let mut stream = net::connect_tcp_endpoint(
             relay_server,
@@ -365,7 +396,7 @@ impl RendezvousClient {
         stream.set_write_timeout(Some(Duration::from_secs(10)))?;
 
         // hbbr uses the same exact shared `-k` comparison as hbbs.
-        let msg = request_relay_message(id, uuid, server_key);
+        let msg = request_relay_message(id, uuid, server_key, token);
         let payload = msg
             .write_to_bytes()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
@@ -664,7 +695,7 @@ mod tests {
     #[test]
     fn arbitrary_shared_access_key_is_preserved_in_punch_and_relay_messages() {
         let key = " =tenant-key:42/abc=\n";
-        let punch = punch_hole_request_message("peer-123", key);
+        let punch = punch_hole_request_message("peer-123", key, "");
         let punch_bytes = punch.write_to_bytes().expect("serialize punch request");
         let parsed_punch: RendezvousMessage = protobuf::parse_from_bytes(&punch_bytes)
             .expect("parse punch request");
@@ -675,7 +706,7 @@ mod tests {
             other => panic!("expected PunchHoleRequest, got: {:?}", other),
         }
 
-        let relay = request_relay_message("peer-123", "uuid-123", key);
+        let relay = request_relay_message("peer-123", "uuid-123", key, "");
         let relay_bytes = relay.write_to_bytes().expect("serialize relay request");
         let parsed_relay: RendezvousMessage = protobuf::parse_from_bytes(&relay_bytes)
             .expect("parse relay request");
@@ -684,6 +715,53 @@ mod tests {
                 assert_eq!(req.get_licence_key(), key);
             }
             other => panic!("expected RequestRelay, got: {:?}", other),
+        }
+    }
+
+    /// Server Pro refuses an unauthenticated punch hole with
+    /// "You have not logged in or your login session has expired", so the
+    /// account token has to survive serialization on both handshake messages.
+    #[test]
+    fn pro_session_token_is_carried_by_punch_and_relay_messages() {
+        let token = "pro-session-token-abc123";
+        let key = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGH=";
+
+        let punch = punch_hole_request_message("peer-123", key, token);
+        let punch_bytes = punch.write_to_bytes().expect("serialize punch request");
+        let parsed_punch: RendezvousMessage =
+            protobuf::parse_from_bytes(&punch_bytes).expect("parse punch request");
+        match parsed_punch.union {
+            Some(RendezvousMessage_oneof_union::punch_hole_request(req)) => {
+                assert_eq!(req.get_token(), token);
+                assert_eq!(req.get_licence_key(), key);
+                assert!(req.get_force_relay());
+            }
+            other => panic!("expected PunchHoleRequest, got: {:?}", other),
+        }
+
+        let relay = request_relay_message("peer-123", "uuid-123", key, token);
+        let relay_bytes = relay.write_to_bytes().expect("serialize relay request");
+        let parsed_relay: RendezvousMessage =
+            protobuf::parse_from_bytes(&relay_bytes).expect("parse relay request");
+        match parsed_relay.union {
+            Some(RendezvousMessage_oneof_union::request_relay(req)) => {
+                assert_eq!(req.get_token(), token);
+                assert_eq!(req.get_licence_key(), key);
+            }
+            other => panic!("expected RequestRelay, got: {:?}", other),
+        }
+    }
+
+    /// An OSS deployment has no account token; the field must stay empty
+    /// rather than being filled with a placeholder.
+    #[test]
+    fn empty_token_stays_empty_for_oss_deployments() {
+        let punch = punch_hole_request_message("peer-123", "", "");
+        match punch.union {
+            Some(RendezvousMessage_oneof_union::punch_hole_request(req)) => {
+                assert!(req.get_token().is_empty());
+            }
+            other => panic!("expected PunchHoleRequest, got: {:?}", other),
         }
     }
 
@@ -769,7 +847,7 @@ mod tests {
         let client = RendezvousClient::new();
         let relay_endpoint = format!("localhost:{}", port);
         let stream = client
-            .create_relay("peer", "uuid", &relay_endpoint, "")
+            .create_relay("peer", "uuid", &relay_endpoint, "", "")
             .expect("relay hostname should resolve and connect");
         drop(stream);
         accept_thread.join().expect("accept thread panicked");

--- a/scripts/build_rustdesk_ffi_ohos.sh
+++ b/scripts/build_rustdesk_ffi_ohos.sh
@@ -76,6 +76,11 @@ for ABI_TARGET in "${ABIS[@]}"; do
             "CXXFLAGS_${TARGET_ENV}=$TARGET_CFLAGS" \
             CC_SHELL_ESCAPED_FLAGS=1 \
             "CARGO_TARGET_${TARGET_ENV_UPPER}_LINKER=$TARGET_CXX" \
+            `# Cargo splits this variable on spaces and never strips quotes, so a` \
+            `# quoted path reaches clang as a literal ''--sysroot=...'' and fails.` \
+            `# CFLAGS above is different: CC_SHELL_ESCAPED_FLAGS=1 makes the cc` \
+            `# crate honour the quoting there. An SDK path containing a space` \
+            `# still needs OHOS_SDK_HOME pointed at a space-free copy.` \
             "CARGO_TARGET_${TARGET_ENV_UPPER}_RUSTFLAGS=-C link-arg=--target=$CLANG_TARGET -C link-arg=--sysroot=$OHOS_SYSROOT" \
             OPUS_LIB_DIR="$OPUS_LIB_DIR" \
             "$CARGO_BIN" build --release --target "$TARGET"


### PR DESCRIPTION
在 HarmonyOS 平板真机上逐项定位并验证的一组连锁问题，覆盖 Server Pro 凭据、
  地址簿密码、会话交接、触控与虚拟键盘输入。

  ## Server Pro 凭据丢失

  `RustDeskProCredentialStore.load()` 在读盘前就置位 `loaded`，catch 里清空
  accounts。一次读取失败和"没有账号"完全不可区分且不再重试，随后任何 `save()`
  都会用空数组覆盖磁盘，token 永久丢失 —— 表现为杀后台后必须重新登录。
  `persist()` 在 context 缺失时静默返回，登录成功、界面显示已登录、磁盘却是空的。
  整个 store 没有任何日志，故障不可见。

  ## 地址簿密码是乱码

  `RustDeskProPeer` 把地址簿的 `hash` 字段 base64 解码后按 UTF-8 当密码。但
  `hash` 是 `SHA256(password+salt)` 的 32 字节摘要，解出来必然是乱码；而且
  `protocol/session.rs` 的认证只接受明文口令、会无条件做两轮 SHA256，喂哈希
  进去永远认证不过。同步还会无条件覆盖用户手动输入的正确密码。

  ## Pro 主机连上后没有任何输入入口

  Pro 主机走的是预鉴权交接路径而非 `connect-success`，该分支漏了
  `handleVisible`，悬浮胶囊不显示；叠加顶栏在非桌面设备触控模式下不显示，
  结果画面正常出图却完全找不到打开键盘的地方。该分支还漏了最近连接时间更新
  和剪贴板桥启动。

  ## 触控模式单击不生效

  远端只在 `MOUSE_TYPE_MOVE` 时移动光标，DOWN/UP 完全忽略事件里的 x/y
  （上游 `server/input_service.rs` 的 `handle_mouse_`），而客户端按键事件不带
  前置移动，第一次轻点会落在上一次的位置。另外 Windows 任务栏/菜单需要先收到
  mouse-enter 才响应点击，光标瞬移后同一毫秒按下会被吞掉。

  三指轻点几乎打不开控制面板：多指手势用触点重心量位移，手指逐根抬起时重心
  骤变，被误判成滑动。

  ## 虚拟键盘

  画布层 `focusOnTouch` 每次点击都抢走影子 TextArea 的输入法焦点，点开远端
  输入框的同时键盘立刻收起，永远无法边点边打字。收起键盘依赖把焦点移到画布层，
  而 `requestFocus` 对画布层会失败，导致键盘按钮只能开不能关。软键盘弹出时
  按远端光标位置把画面让到可见区中部（与官方 `_moveToCenterCursor` 落点一致）。
  悬浮胶囊上新增常驻键盘按钮，一次点击直达。

  ## 华为账号登录

  `AccountKitService.init()` 全项目从未被调用，`dataPreferences` 始终为空，
  凭据从来没有真正落盘也没人读回来，冷启动只能依赖 HMS 静默授权。

  ## 测试

  新增 `RemoteKeyboardAvoidPolicy` 与 `RustDeskProSyncPolicy` 用例；后者此前
  从未注册进 `List.test`，等于死代码，一并接入。

  ArkTS 主源码与测试源码均编译通过，全部行为已在真机验证。单元测试尚未执行，
  需要 on-device hypium runner。