### PR TITLE
fix(vnc): adapt host FAB across device classes

### DIFF
--- a/entry/src/main/ets/components/vnc/VncSheetScaffold.ets
+++ b/entry/src/main/ets/components/vnc/VncSheetScaffold.ets
@@ -133,12 +133,12 @@ export struct VncSheetScaffold {
         this.header()
       }
       if (this.fitContent) {
-        // Phone host-add sheets share one intrinsic content tree with their
+        // VNC host-add sheets share one intrinsic content tree with their
         // action row so bindSheet can translate and scroll it above the IME.
         this.body(true)
       } else {
-        // Settings, trust, Gateway, Pad and PC callers retain a bounded body
-        // and reachable footer inside their LARGE/fixed-height sheet host.
+        // Settings, trust and Gateway callers retain a bounded body and
+        // reachable footer inside their LARGE/fixed-height sheet host.
         Scroll() {
           this.body(false)
         }

--- a/entry/src/main/ets/pages/HostListPage.ets
+++ b/entry/src/main/ets/pages/HostListPage.ets
@@ -17615,14 +17615,14 @@ struct HostListPage {
     Column() {
       this.classicHostEditorTitle()
       if (this.classicHostEditorUsesIntrinsicLayout()) {
-        // Phone VNC follows the FIT_CONTENT Sheet contract: no nested Scroll
-        // or remaining-space weight participates in intrinsic measurement.
+        // VNC Host FABs use the same intrinsic tree on Phone/Pad/PC: no nested
+        // Scroll or remaining-space weight can turn the action row into a bar.
         this.classicHostEditorFields()
       } else {
         Scroll() {
           this.classicHostEditorFields()
         }
-        // Bounded VNC/SSH surfaces keep their established internal viewport.
+        // Other bounded classic surfaces keep their established viewport.
         .constraintSize({ maxHeight: this.proto === 'vnc' ? '100%' : 420 })
         .layoutWeight(this.proto === 'vnc' ? 1 : 0)
         .scrollBar(BarState.Auto)

--- a/entry/src/main/ets/services/HostAddSheetLayoutPolicy.ets
+++ b/entry/src/main/ets/services/HostAddSheetLayoutPolicy.ets
@@ -12,33 +12,25 @@ export function resolveActiveHostAddProtocol(modernProtocol: string,
 }
 
 /**
- * Phone bottom sheets follow the active wizard step's intrinsic height.
- * Pad/PC retain the established large centered surface for long VNC/SSH
- * forms, where the extra space is intentional.
+ * VNC host-add sheets follow the active wizard step's intrinsic height on
+ * every device class. Pad/PC retain the established large SSH workspace.
  */
 export function resolveHostAddSheetHeightMode(protocol: string,
   breakpoint: string): HostAddSheetHeightMode {
-  const longFlow: boolean = protocol === 'vnc' || protocol === 'ssh';
-  if (longFlow && breakpoint !== 'sm') {
+  if (protocol === 'ssh' && breakpoint !== 'sm') {
     return 'large';
   }
   return 'fit';
 }
 
-/**
- * Phone VNC uses the same system-owned IME translation as the other FAB
- * forms. Bounded Pad/PC VNC sheets keep their internal scroll viewport.
- */
-export function resolveHostAddSheetKeyboardAvoidMode(protocol: string,
-  breakpoint: string): HostAddSheetKeyboardAvoidMode {
-  if (protocol === 'vnc' && breakpoint !== 'sm') {
-    return 'resize';
-  }
+/** Every host-add FAB delegates IME movement and overflow to bindSheet. */
+export function resolveHostAddSheetKeyboardAvoidMode(_protocol: string,
+  _breakpoint: string): HostAddSheetKeyboardAvoidMode {
   return 'translateAndScroll';
 }
 
-/** Only the phone VNC host-add flow opts into the intrinsic scaffold. */
+/** Every VNC host-add FAB uses one intrinsic content tree on Phone/Pad/PC. */
 export function resolveHostAddSheetContentMode(protocol: string,
-  breakpoint: string): HostAddSheetContentMode {
-  return protocol === 'vnc' && breakpoint === 'sm' ? 'fitContent' : 'bounded';
+  _breakpoint: string): HostAddSheetContentMode {
+  return protocol === 'vnc' ? 'fitContent' : 'bounded';
 }

--- a/entry/src/test/HostAddSheetLayoutPolicy.test.ets
+++ b/entry/src/test/HostAddSheetLayoutPolicy.test.ets
@@ -20,23 +20,23 @@ export default function hostAddSheetLayoutPolicyTest(): void {
     });
 
     it('keeps_pad_long_flows_usable', 0, (): void => {
-      expect(resolveHostAddSheetHeightMode('vnc', 'md')).assertEqual('large');
+      expect(resolveHostAddSheetHeightMode('vnc', 'md')).assertEqual('fit');
       expect(resolveHostAddSheetHeightMode('ssh', 'md')).assertEqual('large');
       expect(resolveHostAddSheetKeyboardAvoidMode('vnc', 'md'))
-        .assertEqual('resize');
+        .assertEqual('translateAndScroll');
       expect(resolveHostAddSheetKeyboardAvoidMode('ssh', 'md'))
         .assertEqual('translateAndScroll');
-      expect(resolveHostAddSheetContentMode('vnc', 'md')).assertEqual('bounded');
+      expect(resolveHostAddSheetContentMode('vnc', 'md')).assertEqual('fitContent');
     });
 
     it('keeps_pc_long_flows_usable', 0, (): void => {
-      expect(resolveHostAddSheetHeightMode('vnc', 'xl')).assertEqual('large');
+      expect(resolveHostAddSheetHeightMode('vnc', 'xl')).assertEqual('fit');
       expect(resolveHostAddSheetHeightMode('ssh', 'xl')).assertEqual('large');
       expect(resolveHostAddSheetKeyboardAvoidMode('vnc', 'xl'))
-        .assertEqual('resize');
+        .assertEqual('translateAndScroll');
       expect(resolveHostAddSheetKeyboardAvoidMode('ssh', 'xl'))
         .assertEqual('translateAndScroll');
-      expect(resolveHostAddSheetContentMode('vnc', 'xl')).assertEqual('bounded');
+      expect(resolveHostAddSheetContentMode('vnc', 'xl')).assertEqual('fitContent');
     });
 
     it('routes_classic_protocols_before_resolving_sheet_layout', 0, (): void => {
@@ -48,6 +48,8 @@ export default function hostAddSheetLayoutPolicyTest(): void {
       const classicPhoneVnc: string = resolveActiveHostAddProtocol('', 'vnc', false);
       const classicPadSsh: string = resolveActiveHostAddProtocol('', 'ssh', false);
       expect(resolveHostAddSheetContentMode(classicPhoneVnc, 'sm')).assertEqual('fitContent');
+      expect(resolveHostAddSheetContentMode(classicPhoneVnc, 'md')).assertEqual('fitContent');
+      expect(resolveHostAddSheetContentMode(classicPhoneVnc, 'xl')).assertEqual('fitContent');
       expect(resolveHostAddSheetHeightMode(classicPadSsh, 'md')).assertEqual('large');
     });
 


### PR DESCRIPTION
## Summary
- apply the adaptive VNC host-add Sheet layout policy across Phone, Pad, PC/2in1, and freeform windows
- align modern and classic VNC host-add surfaces with the shared fit/scroll contract
- extend the device-class policy matrix tests

## Validation
- default@OhosTestCompileArkTS: PASS
- assembleHap: PASS
- git diff --check: PASS
- open-source compliance Light in a clean local clone: PASS
- independent review: PASS (P0/P1/P2=0; one non-blocking P3 for future direct component-tree/device coverage)